### PR TITLE
Integrate protect in tracing

### DIFF
--- a/python/fi_instrumentation/instrumentation/_protect_wrapper.py
+++ b/python/fi_instrumentation/instrumentation/_protect_wrapper.py
@@ -83,11 +83,18 @@ class GuardrailProtectWrapper:
     ) -> Iterator[trace_api.Span]:
         """Creates and manages a span with proper context handling."""
         try:
-            span = self._tracer.start_span(
-                name=span_name,
-                kind=SpanKind.INTERNAL,
-                attributes=attributes,
-            )
+            if hasattr(self._tracer, '_tracer'):
+                span = self._tracer._tracer.start_span(
+                    name=span_name,
+                    kind=SpanKind.INTERNAL,
+                    attributes=attributes,
+                )
+            else:
+                span = self._tracer.start_span(
+                    name=span_name,
+                    kind=SpanKind.INTERNAL,
+                    attributes=attributes,
+                )
         except Exception as e:
             logger.error(f"Error creating span: {e}", exc_info=True)
             span = trace_api.INVALID_SPAN

--- a/python/fi_instrumentation/instrumentation/_protect_wrapper.py
+++ b/python/fi_instrumentation/instrumentation/_protect_wrapper.py
@@ -1,0 +1,156 @@
+import logging
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple
+from contextlib import contextmanager
+from itertools import chain
+
+from fi_instrumentation import get_attributes_from_context, safe_json_dumps
+from fi_instrumentation.fi_types import FiSpanKindValues, SpanAttributes
+from opentelemetry import trace as trace_api
+from opentelemetry import context as context_api
+from opentelemetry.trace import Status, StatusCode, Tracer, SpanKind
+from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
+
+logger = logging.getLogger(__name__)
+
+# Constants for Guardrail span attributes
+GUARDRAIL_TYPE = f"{SpanAttributes.FI_SPAN_KIND}.guardrail.type"
+GUARDRAIL_RULES = f"{SpanAttributes.FI_SPAN_KIND}.guardrail.rules"
+GUARDRAIL_STATUS = f"{SpanAttributes.FI_SPAN_KIND}.guardrail.status"
+GUARDRAIL_FAILED_RULE = f"{SpanAttributes.FI_SPAN_KIND}.guardrail.failed_rule"
+GUARDRAIL_REASONS = f"{SpanAttributes.FI_SPAN_KIND}.guardrail.reasons"
+GUARDRAIL_TIME_TAKEN = f"{SpanAttributes.FI_SPAN_KIND}.guardrail.time_taken"
+GUARDRAIL_COMPLETED_RULES = f"{SpanAttributes.FI_SPAN_KIND}.guardrail.completed_rules"
+GUARDRAIL_UNCOMPLETED_RULES = f"{SpanAttributes.FI_SPAN_KIND}.guardrail.uncompleted_rules"
+
+def _get_raw_input(inputs: Any) -> Iterator[Tuple[str, Any]]:
+    """Generates raw input attributes for the protect span."""
+    try:
+        yield SpanAttributes.RAW_INPUT, safe_json_dumps(inputs)
+    except Exception as e:
+        logger.warning(f"Failed to serialize raw guardrail inputs: {e}", exc_info=True)
+def _get_raw_output(result: Dict[str, Any]) -> Iterator[Tuple[str, Any]]:
+    """Generates raw output attributes for the protect span."""
+    try:
+        yield SpanAttributes.RAW_OUTPUT, safe_json_dumps(result)
+    except Exception as e:
+        logger.warning(f"Failed to serialize raw guardrail output: {e}", exc_info=True)
+
+def _get_protect_input(inputs: Any) -> Iterator[Tuple[str, Any]]:
+    """Generates input attributes for the protect span."""
+    try:
+        yield SpanAttributes.INPUT_VALUE, safe_json_dumps(inputs)
+        yield SpanAttributes.INPUT_MIME_TYPE, "text/plain"
+    except Exception as e:
+        logger.warning(f"Failed to serialize guardrail inputs: {e}", exc_info=True)
+
+def _get_protect_rules(rules: List[Dict[str, Any]]) -> Iterator[Tuple[str, Any]]:
+    """Generates rule attributes for the protect span."""
+    try:
+        yield GUARDRAIL_RULES, safe_json_dumps(rules)
+    except Exception as e:
+        logger.warning(f"Failed to serialize guardrail rules: {e}", exc_info=True)
+
+def _get_protect_output(result: Dict[str, Any]) -> Iterator[Tuple[str, Any]]:
+    """Generates output attributes for the protect span."""
+    try:
+        yield SpanAttributes.OUTPUT_VALUE, safe_json_dumps(result)
+        yield SpanAttributes.OUTPUT_MIME_TYPE, "application/json"
+        
+        if status := result.get("status"):
+            yield GUARDRAIL_STATUS, status
+        if failed_rule := result.get("failed_rule"):
+            yield GUARDRAIL_FAILED_RULE, failed_rule
+        if reasons := result.get("reasons"):
+            yield GUARDRAIL_REASONS, safe_json_dumps(reasons)
+        if time_taken := result.get("time_taken"):
+            yield GUARDRAIL_TIME_TAKEN, time_taken
+        if completed := result.get("completed_rules"):
+            yield GUARDRAIL_COMPLETED_RULES, safe_json_dumps(completed)
+        if uncompleted := result.get("uncompleted_rules"):
+            yield GUARDRAIL_UNCOMPLETED_RULES, safe_json_dumps(uncompleted)
+    except Exception as e:
+        logger.warning(f"Failed to serialize guardrail output: {e}", exc_info=True)
+
+class GuardrailProtectWrapper:
+    """Wraps the fi.evals.ProtectClient.protect method to create a Guardrail span."""
+
+    def __init__(self, tracer: Tracer):
+        self._tracer = tracer
+
+    @contextmanager
+    def _start_as_current_span(
+        self, span_name: str, attributes: Optional[Mapping[str, Any]] = None
+    ) -> Iterator[trace_api.Span]:
+        """Creates and manages a span with proper context handling."""
+        try:
+            span = self._tracer.start_span(
+                name=span_name,
+                kind=SpanKind.INTERNAL,
+                attributes=attributes,
+            )
+        except Exception as e:
+            logger.error(f"Error creating span: {e}", exc_info=True)
+            span = trace_api.INVALID_SPAN
+
+        with trace_api.use_span(
+            span,
+            end_on_exit=True,
+            record_exception=True,
+            set_status_on_exception=True,
+        ) as current_span:
+            yield current_span
+
+    def __call__(
+        self,
+        wrapped: Any,
+        instance: Any,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        """Executes the wrapped protect method and creates a span."""
+        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+
+        inputs = kwargs.get("inputs") or (args[0] if args else None)
+        protect_rules = kwargs.get("protect_rules") or (args[1] if len(args) > 1 else None)
+
+        if not inputs or not protect_rules:
+            logger.debug("Guardrail protect called without inputs or rules. Skipping tracing.")
+            return wrapped(*args, **kwargs)
+
+        with self._start_as_current_span(
+            span_name="Guardrail.protect",
+            attributes=dict(
+                chain(
+                    get_attributes_from_context(),
+                    [(SpanAttributes.FI_SPAN_KIND, FiSpanKindValues.GUARDRAIL.value)],
+                    [(GUARDRAIL_TYPE, "protect")],
+                    _get_protect_input(inputs),
+                    _get_protect_rules(protect_rules),
+                    _get_raw_input(inputs),
+                )
+            ),
+        ) as span:
+            try:
+                result = wrapped(*args, **kwargs)
+                
+                span.set_attributes(dict(
+                    chain(
+                        _get_protect_output(result),
+                        _get_raw_output(result),
+                    )
+                ))
+                
+                if result.get("status") == "passed":
+                    span.set_status(Status(StatusCode.OK))
+                else:
+                    failed_rule = result.get("failed_rule", "unknown")
+                    span.set_status(Status(StatusCode.ERROR, f"Guardrail check failed: {failed_rule}"))
+                
+                return result
+
+            except Exception as e:
+                span.record_exception(e)
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                logger.error(f"Exception during protect call: {e}", exc_info=True)
+                raise 

--- a/python/frameworks/anthropic/examples/guardrail_example
+++ b/python/frameworks/anthropic/examples/guardrail_example
@@ -1,0 +1,93 @@
+"""
+Example showing how to use the guardrail tracing with Anthropic.
+"""
+import os
+import time
+from anthropic import Anthropic
+from fi.evals import ProtectClient, EvalClient
+from fi_instrumentation import register
+from traceai_anthropic import AnthropicInstrumentor
+from fi_instrumentation.instrumentation.config import TraceConfig
+from fi_instrumentation.fi_types import ProjectType
+from opentelemetry import trace
+
+# Initialize tracer
+
+tracer_provider = register(
+    project_type=ProjectType.OBSERVE,
+    # eval_tags=eval_tags,
+    project_name="FUTURE_AGI",
+    # project_version_name="v1",
+)
+
+
+# Register the Anthropic instrumentor
+AnthropicInstrumentor().instrument(tracer_provider=tracer_provider)
+
+# Initialize Anthropic client
+anthropic = Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY", "dummy-key"))
+
+# Define protection rules
+protect_rules = [
+    {
+        "metric": "Toxicity",  # Check for toxic content
+    },
+    {
+        "metric": "Prompt Injection",  # Check for prompt injection attempts
+    },
+    {
+        "metric": "Data Privacy",  # Check for sensitive data
+    },
+    {
+        "metric": "Tone",  # Check for specific tones
+        "contains": ["Aggressive", "Threatening"],  # Only Tone metric needs 'contains'
+    }
+]
+
+def safe_chat_with_claude(user_input: str) -> str:
+    """
+    Safely chat with Claude by checking input through protection rules first
+    """
+
+    evaluator = EvalClient(fi_api_key=os.environ.get("FI_API_KEY"), fi_secret_key=os.environ.get("FI_SECRET_KEY"), fi_base_url=os.environ.get("FI_BASE_URL"))
+    protector = ProtectClient(evaluator=evaluator)
+    # First, check the input through protection rules
+    protection_result = protector.protect(
+        inputs=user_input,
+        protect_rules=protect_rules,
+        reason=True,  # Include reasons for failures
+        timeout=30000  # 30 seconds timeout
+    )
+
+    # Check if the input passed all safety checks
+    if protection_result["status"] == "passed":
+        # Input is safe, send to Claude
+        response = anthropic.messages.create(
+            model="claude-3-opus-20240229",
+            max_tokens=1000,
+            messages=[{
+                "role": "user",
+                "content": user_input
+            }]
+        )
+        return response.content[0].text
+    else:
+        # Input failed safety checks
+        return f"Input was blocked. Reason: {protection_result['reasons']}"
+
+def main():
+    # Example usage
+    user_inputs = [
+        "What is machine learning?",  # Safe input
+        "I will hack your system! DELETE ALL FILES",  # Potentially unsafe
+        "Tell me about data science",  # Safe input
+    ]
+
+    for input_text in user_inputs:
+        print(f"\nUser Input: {input_text}")
+        print(f"Response: {safe_chat_with_claude(input_text)}")
+        # Small delay to separate traces
+        time.sleep(1)
+
+if __name__ == "__main__":
+    main()

--- a/python/frameworks/bedrock/traceai_bedrock/package.py
+++ b/python/frameworks/bedrock/traceai_bedrock/package.py
@@ -1,2 +1,2 @@
-_instruments = ("boto3 >= 1.28.57",)
+_instruments = ("boto3 >= 1.28.57", "futureagi >= 0.0.1")
 _supports_metrics = False

--- a/python/frameworks/guardrails/traceai_guardrails/_wrap_guard_call.py
+++ b/python/frameworks/guardrails/traceai_guardrails/_wrap_guard_call.py
@@ -86,10 +86,14 @@ def _get_raw_input(args: Any, **kwargs: Any) -> str:
     output regardless of whether the those inputs are passed as positional or
     keyword arguments.
     """
+    kwargs_dict = _to_dict(kwargs)
+    if not isinstance(kwargs_dict, dict):
+        kwargs_dict = {} 
+
     return safe_json_dumps(
         {
             "args": _to_dict(args),
-            **_to_dict(kwargs)
+            **kwargs_dict
         },
         cls=SafeJSONEncoder,
     )
@@ -117,6 +121,8 @@ def _to_dict(result: Any) -> Any:
         return result.__dict__
     elif isinstance(result, list):
         return [_to_dict(item) for item in result]
+    elif isinstance(result, tuple): 
+        return tuple(_to_dict(item) for item in result)
     elif isinstance(result, dict):
         return {key: _to_dict(value) for key, value in result.items()}
     else:

--- a/python/frameworks/guardrails/traceai_guardrails/guardrails_example.py
+++ b/python/frameworks/guardrails/traceai_guardrails/guardrails_example.py
@@ -1,0 +1,39 @@
+from fi_instrumentation import register
+from fi_instrumentation.fi_types import ProjectType
+import os
+from guardrails import Guard, OnFailAction
+from traceai_guardrails import GuardrailsInstrumentor
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# --- Setup Instrumentation ---
+# This setup registers the project with the FI observability platform
+# and instruments the Guardrails library to send OTel spans.
+trace_provider = register(
+    project_type=ProjectType.OBSERVE,
+    project_name="GUARDRAILSPAN2",
+    session_name="GUARDRAILSPAN2",
+)
+
+GuardrailsInstrumentor().instrument(tracer_provider=trace_provider)
+
+#from guardrails import Guard, OnFailAction
+from guardrails.hub import CompetitorCheck, ToxicLanguage
+
+guard = Guard().use_many(
+    CompetitorCheck(["Apple", "Microsoft", "Google"], on_fail=OnFailAction.EXCEPTION),
+    ToxicLanguage(threshold=0.5, validation_method="sentence", on_fail=OnFailAction.EXCEPTION)
+)
+
+guard.validate(
+    """An apple a day keeps a doctor away.
+    This is good advice for keeping your health."""
+)  # Both the guardrails pass
+
+try:
+    guard.validate(
+        """Shut the hell up! Apple just released a new iPhone."""
+    )  # Both the guardrails fail
+except Exception as e:
+    print(e)

--- a/python/frameworks/langchain/examples/tool_calling_agent.py
+++ b/python/frameworks/langchain/examples/tool_calling_agent.py
@@ -43,9 +43,9 @@ eval_tags = [
 def setup_instrumentation():
     """Configure and initialize OpenTelemetry instrumentation."""
     trace_provider = register(
-        project_name="LANGCHAIN_TOOL_CALLING_OBSERVE_V3",
+        project_name="GUARDRAILSPAN2",
         project_type=ProjectType.OBSERVE,
-        session_name="V2",
+        session_name="GUARDRAILSPAN2",
         # project_version_name="V2",
         # eval_tags=eval_tags,
     )
@@ -305,7 +305,11 @@ def main():
     },
     {
         "metric": "Toxicity"
-    }
+    },
+    {
+        "metric": "Prompt Injection",
+    },
+
 ]
     results = []
     for query in queries:
@@ -315,7 +319,7 @@ def main():
             agent_result = agent_executor.invoke({"input": query})
             
             # Guardrail execution should also inherit context from parent_span
-            protect_result = protector.protect(inputs=query, protect_rules=rules) # Protecting original query for now
+            protect_result = protector.protect(inputs=query, protect_rules=rules, action="block", reason=True) # Protecting original query for now
             
             # Add attributes to the parent span
             parent_span.set_attribute("agent.output", str(agent_result.get('output', '')))

--- a/python/frameworks/langchain/traceai_langchain/package.py
+++ b/python/frameworks/langchain/traceai_langchain/package.py
@@ -1,2 +1,2 @@
-_instruments = ("langchain_core >= 0.1.0",)
+_instruments = ("langchain_core >= 0.1.0", "futureagi")
 _supports_metrics = False

--- a/python/frameworks/langchain/traceai_langchain/package.py
+++ b/python/frameworks/langchain/traceai_langchain/package.py
@@ -1,2 +1,2 @@
-_instruments = ("langchain_core >= 0.1.0", "futureagi")
+_instruments = ("langchain_core >= 0.1.0", "futureagi >= 0.0.1")
 _supports_metrics = False

--- a/python/frameworks/litellm/traceai_litellm/package.py
+++ b/python/frameworks/litellm/traceai_litellm/package.py
@@ -1,2 +1,2 @@
-_instruments = ("litellm >= 1.43.0",)
+_instruments = ("litellm >= 1.43.0", "futureagi >= 0.0.1")
 _supports_metrics = False

--- a/python/frameworks/llama_index/traceai_llamaindex/__init__.py
+++ b/python/frameworks/llama_index/traceai_llamaindex/__init__.py
@@ -7,7 +7,9 @@ from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type:
 from opentelemetry.trace import Span
 from traceai_llamaindex.package import _instruments
 from traceai_llamaindex.version import __version__
-
+from fi_instrumentation.instrumentation._protect_wrapper import GuardrailProtectWrapper
+from fi.evals import ProtectClient
+from wrapt import wrap_function_wrapper
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
@@ -83,6 +85,12 @@ class LlamaIndexInstrumentor(BaseInstrumentor):  # type: ignore
             else:
                 dispatcher.add_event_handler(self._event_handler)
 
+        self._original_protect = ProtectClient.protect
+        wrap_function_wrapper(
+            module="fi.evals",
+            name="ProtectClient.protect",
+            wrapper=GuardrailProtectWrapper(tracer=self._tracer),
+        )
     def _uninstrument(self, **kwargs: Any) -> None:
         if self._use_legacy_callback_handler:
             import llama_index.core

--- a/python/frameworks/llama_index/traceai_llamaindex/package.py
+++ b/python/frameworks/llama_index/traceai_llamaindex/package.py
@@ -1,2 +1,2 @@
-_instruments = ("llama-index-core >= 0.10.43",)
+_instruments = ("llama-index-core >= 0.10.43", "futureagi >= 0.0.1")
 _supports_metrics = False

--- a/python/frameworks/openai/traceai_openai/package.py
+++ b/python/frameworks/openai/traceai_openai/package.py
@@ -1,2 +1,2 @@
-_instruments = ("openai >= 1.0.0",)
+_instruments = ("openai >= 1.0.0", "futureagi >= 0.0.1")
 _supports_metrics = False

--- a/python/frameworks/vertexai/traceai_vertexai/package.py
+++ b/python/frameworks/vertexai/traceai_vertexai/package.py
@@ -1,2 +1,2 @@
-_instruments = ("google-cloud-aiplatform >= 1.49.0",)
+_instruments = ("google-cloud-aiplatform >= 1.49.0", "futureagi >= 0.0.1")
 _supports_metrics = False


### PR DESCRIPTION
# Pull Request

## Description
Describe the changes in this pull request:
- What feature/bug does this PR address?
Added Tracing Feature for Protect from Future AGI SDK


Notion Ticket Link : [notion_ticket](https://www.notion.so/future-ai/Integrate-protect-in-observe-or-prototype-1c71cecdacb7800693badb9dd103b566?pvs=4)
- Provide any relevant links or screenshots.

## Checklist
- [ ] Code compiles correctly.
- [ ] Created/updated tests.
- [ ] Linting and formatting applied.
- [ ] Documentation updated.

## Related Issues
Closes #<issue_number>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tracing and telemetry for Guardrail protection calls across multiple frameworks, enabling detailed observability of input, rules, outputs, and errors.
  - Introduced example scripts demonstrating Guardrail integration and tracing with Anthropic Claude, Guardrails, and LangChain agents.
- **Enhancements**
  - Expanded instrumentation to wrap Guardrail protection logic in Anthropic, Bedrock, Groq, Haystack, Instructor, LangChain, LiteLLM, LlamaIndex, OpenAI, and VertexAI frameworks.
  - Updated dependency requirements to include Guardrail support in relevant packages.
- **Bug Fixes**
  - Improved argument serialization and error handling for Guardrail tracing in Guardrails instrumentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->