### PR TITLE
[feat] updated HTTPSpanExporter to use default otel export method

### DIFF
--- a/python/fi_instrumentation/fi_types.py
+++ b/python/fi_instrumentation/fi_types.py
@@ -494,7 +494,7 @@ class ToolAttributes:
 
 class Endpoints(Enum):
     FUTURE_AGI = (
-        f"{get_env_collector_endpoint()}/tracer/observation-span/create_otel_span/"
+        f"{get_env_collector_endpoint()}/tracer/v1/traces"
     )
 
 


### PR DESCRIPTION
# Pull Request

## Description
Describe the changes in this pull request:
- updated HTTPSpanExporter to use default otel export method to make our SDKs and BE compatible with the standard otel implementaion

## Checklist
- [ ] Code compiles correctly.
- [ ] Created/updated tests.
- [ ] Linting and formatting applied.
- [ ] Documentation updated.

## Related Issues
Fixed TH-914
