### PR TITLE
[Release] Bump core packages to 1.0.0

### DIFF
--- a/csharp/src/FIInstrumentation/FIInstrumentation.csproj
+++ b/csharp/src/FIInstrumentation/FIInstrumentation.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>FIInstrumentation</RootNamespace>
     <AssemblyName>FIInstrumentation</AssemblyName>
     <PackageId>fi-instrumentation-otel</PackageId>
-    <Version>0.1.0</Version>
+    <Version>1.0.0</Version>
     <Authors>FutureAGI</Authors>
     <Description>traceAI C# instrumentation SDK for OpenTelemetry-based LLM observability</Description>
     <LangVersion>latest</LangVersion>

--- a/java/examples/azure-openai-example/pom.xml
+++ b/java/examples/azure-openai-example/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.traceai.examples</groupId>
     <artifactId>azure-openai-example</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>TraceAI Azure OpenAI Example</name>
     <description>Example demonstrating TraceAI instrumentation with Azure OpenAI Java SDK</description>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>ai.traceai</groupId>
             <artifactId>traceai-java-azure-openai</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!-- Azure OpenAI SDK -->

--- a/java/examples/azure-search-example/pom.xml
+++ b/java/examples/azure-search-example/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.traceai.examples</groupId>
     <artifactId>azure-search-example</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>TraceAI Azure Search Example</name>
     <description>Example demonstrating TraceAI instrumentation with Azure AI Search</description>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>ai.traceai</groupId>
             <artifactId>traceai-java-azure-search</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!-- Azure Search Documents SDK -->

--- a/java/examples/elasticsearch-example/pom.xml
+++ b/java/examples/elasticsearch-example/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.traceai.examples</groupId>
     <artifactId>elasticsearch-example</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>TraceAI Elasticsearch Example</name>
     <description>Example demonstrating TraceAI instrumentation with Elasticsearch vector search</description>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>ai.traceai</groupId>
             <artifactId>traceai-java-elasticsearch</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!-- Elasticsearch Java Client -->

--- a/java/examples/langchain4j-example/pom.xml
+++ b/java/examples/langchain4j-example/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.traceai.examples</groupId>
     <artifactId>langchain4j-example</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>TraceAI LangChain4j Example</name>
 
     <properties>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>ai.traceai</groupId>
             <artifactId>traceai-langchain4j</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/java/examples/openai-example/pom.xml
+++ b/java/examples/openai-example/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.traceai.examples</groupId>
     <artifactId>openai-example</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>TraceAI OpenAI Example</name>
 
     <properties>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>ai.traceai</groupId>
             <artifactId>traceai-java-openai</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.openai</groupId>

--- a/java/examples/pgvector-example/pom.xml
+++ b/java/examples/pgvector-example/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.traceai.examples</groupId>
     <artifactId>pgvector-example</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>TraceAI PgVector Example</name>
     <description>Example demonstrating TraceAI instrumentation with PostgreSQL pgvector</description>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>ai.traceai</groupId>
             <artifactId>traceai-java-pgvector</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!-- pgvector Java library -->

--- a/java/examples/rag-example/pom.xml
+++ b/java/examples/rag-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/java/examples/semantic-kernel-example/pom.xml
+++ b/java/examples/semantic-kernel-example/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.traceai.examples</groupId>
     <artifactId>semantic-kernel-example</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>TraceAI Semantic Kernel Example</name>
     <description>Example demonstrating TraceAI instrumentation with Microsoft Semantic Kernel</description>
 
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>ai.traceai</groupId>
             <artifactId>traceai-java-semantic-kernel</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!-- Microsoft Semantic Kernel API -->

--- a/java/examples/spring-ai-example/pom.xml
+++ b/java/examples/spring-ai-example/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>ai.traceai.examples</groupId>
     <artifactId>spring-ai-example</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>TraceAI Spring AI Example</name>
 
     <properties>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>ai.traceai</groupId>
             <artifactId>traceai-spring-boot-starter</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!-- Spring AI OpenAI -->

--- a/java/examples/watsonx-example/pom.xml
+++ b/java/examples/watsonx-example/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.traceai.examples</groupId>
     <artifactId>watsonx-example</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>TraceAI Watsonx Example</name>
     <description>Example demonstrating TraceAI instrumentation with IBM watsonx.ai Java SDK</description>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>ai.traceai</groupId>
             <artifactId>traceai-java-watsonx</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!-- IBM watsonx.ai SDK -->

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.traceai</groupId>
     <artifactId>traceai-java-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>pom</packaging>
 
     <name>TraceAI Java SDK</name>

--- a/java/traceai-java-anthropic/pom.xml
+++ b/java/traceai-java-anthropic/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-anthropic</artifactId>

--- a/java/traceai-java-azure-openai/pom.xml
+++ b/java/traceai-java-azure-openai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-azure-openai</artifactId>

--- a/java/traceai-java-azure-search/pom.xml
+++ b/java/traceai-java-azure-search/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-azure-search</artifactId>

--- a/java/traceai-java-bedrock/pom.xml
+++ b/java/traceai-java-bedrock/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-bedrock</artifactId>

--- a/java/traceai-java-chromadb/pom.xml
+++ b/java/traceai-java-chromadb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-chromadb</artifactId>

--- a/java/traceai-java-cohere/pom.xml
+++ b/java/traceai-java-cohere/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-cohere</artifactId>

--- a/java/traceai-java-core/pom.xml
+++ b/java/traceai-java-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-core</artifactId>

--- a/java/traceai-java-elasticsearch/pom.xml
+++ b/java/traceai-java-elasticsearch/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-elasticsearch</artifactId>

--- a/java/traceai-java-google-genai/pom.xml
+++ b/java/traceai-java-google-genai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-google-genai</artifactId>

--- a/java/traceai-java-milvus/pom.xml
+++ b/java/traceai-java-milvus/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-milvus</artifactId>

--- a/java/traceai-java-mongodb/pom.xml
+++ b/java/traceai-java-mongodb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-mongodb</artifactId>

--- a/java/traceai-java-ollama/pom.xml
+++ b/java/traceai-java-ollama/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-ollama</artifactId>

--- a/java/traceai-java-openai/pom.xml
+++ b/java/traceai-java-openai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-openai</artifactId>

--- a/java/traceai-java-pgvector/pom.xml
+++ b/java/traceai-java-pgvector/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-pgvector</artifactId>

--- a/java/traceai-java-pinecone/pom.xml
+++ b/java/traceai-java-pinecone/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-pinecone</artifactId>

--- a/java/traceai-java-qdrant/pom.xml
+++ b/java/traceai-java-qdrant/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-qdrant</artifactId>

--- a/java/traceai-java-redis/pom.xml
+++ b/java/traceai-java-redis/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-redis</artifactId>

--- a/java/traceai-java-semantic-kernel/pom.xml
+++ b/java/traceai-java-semantic-kernel/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-semantic-kernel</artifactId>

--- a/java/traceai-java-vertexai/pom.xml
+++ b/java/traceai-java-vertexai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-vertexai</artifactId>

--- a/java/traceai-java-watsonx/pom.xml
+++ b/java/traceai-java-watsonx/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-watsonx</artifactId>

--- a/java/traceai-java-weaviate/pom.xml
+++ b/java/traceai-java-weaviate/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-java-weaviate</artifactId>

--- a/java/traceai-langchain4j/pom.xml
+++ b/java/traceai-langchain4j/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-langchain4j</artifactId>

--- a/java/traceai-spring-ai/pom.xml
+++ b/java/traceai-spring-ai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-spring-ai</artifactId>

--- a/java/traceai-spring-boot-starter/pom.xml
+++ b/java/traceai-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.traceai</groupId>
         <artifactId>traceai-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>traceai-spring-boot-starter</artifactId>

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fi-instrumentation-otel"
-version = "0.1.16"
+version = "1.0.0"
 description = "OpenTelemetry instrumentation"
 authors = ["Future AGI <no-reply@futureagi.com>"]
 readme = "README.md"

--- a/typescript/packages/fi-core/package.json
+++ b/typescript/packages/fi-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traceai/fi-core",
-  "version": "0.1.16",
+  "version": "1.0.0",
   "description": "Core OpenTelemetry instrumentation for TypeScript",
   "main": "./dist/src/index.js",
   "module": "./dist/esm/index.js",

--- a/typescript/packages/fi-semantic-conventions/package.json
+++ b/typescript/packages/fi-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traceai/fi-semantic-conventions",
-  "version": "0.1.10",
+  "version": "1.0.0",
   "description": "Semantic conventions for OpenTelemetry instrumentation",
   "main": "./dist/src/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
  - Bumps core SDK packages to 1.0.0 across all languages                                                                                                                                                            
  - Python `fi-instrumentation-otel`: 0.1.16 → 1.0.0                                                                                                                                                                 
  - TypeScript `@traceai/fi-core`: 0.1.16 → 1.0.0                                                                                                                                                                    
  - TypeScript `@traceai/fi-semantic-conventions`: 0.1.10 → 1.0.0                                                                                                                                                    
  - Java parent + all 24 modules: 0.1.0-SNAPSHOT → 1.0.0                                                                                                                                                             
  - C# `FIInstrumentation`: 0.1.0 → 1.0.0                                                                                                                                                                            
                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                       
  - [x] Python e2e tests pass (45/45 instrumentation tests)                                                                                                                                                          
  - [x] TypeScript unit tests pass (300+ tests across 10 packages)                                                                                                                                                   
  - [x] Java Google GenAI e2e passes (4/4)                                                                                                                                                                           
  - [x] C# e2e passes (5/5)                                                                                                                                                                                          
  - [x] All framework dependency specs compatible with 1.0.0                                                                                                                                                         
                                                                    