### PR TITLE
fix: preserve full input context in span attributes for multi-message…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced streaming support
 - Performance optimizations
 
+### Python
+
+#### fi-instrumentation-otel (Core)
+- 🐛 Fix issue where SpanAttributes.INPUT_VALUE was overwritten multiple times, causing loss of context for multi-message inputs (fixes #151)
+
 ---
 
 ## [2025-07-08]

--- a/python/fi_instrumentation/fi_types.py
+++ b/python/fi_instrumentation/fi_types.py
@@ -203,7 +203,6 @@ class SpanAttributes:
     OUTPUT_MIME_TYPE = "output.mime_type"
     INPUT_VALUE = "input.value"
     INPUT_MIME_TYPE = "input.mime_type"
-    INPUT_RAW = "input.raw"
 
     # Embeddings
     EMBEDDING_EMBEDDINGS = "embedding.embeddings"

--- a/python/fi_instrumentation/fi_types.py
+++ b/python/fi_instrumentation/fi_types.py
@@ -203,6 +203,7 @@ class SpanAttributes:
     OUTPUT_MIME_TYPE = "output.mime_type"
     INPUT_VALUE = "input.value"
     INPUT_MIME_TYPE = "input.mime_type"
+    INPUT_RAW = "input.raw"
 
     # Embeddings
     EMBEDDING_EMBEDDINGS = "embedding.embeddings"

--- a/python/frameworks/openai/traceai_openai/_span_io_handler.py
+++ b/python/frameworks/openai/traceai_openai/_span_io_handler.py
@@ -50,9 +50,6 @@ def _process_input_data(input_data: Any, span: _WithSpan) -> None:
                 else:
                     input_content.append(msg)
                     eval_input.append(msg_content)
-        if input_content:
-            input_raw = json.dumps(input_content, ensure_ascii=False)
-            span.set_attribute(SpanAttributes.INPUT_RAW, input_raw)
         if input_images:
             images_value = json.dumps(input_images, ensure_ascii=False)
             span.set_attribute(SpanAttributes.INPUT_IMAGES, images_value)

--- a/python/frameworks/openai/traceai_openai/_span_io_handler.py
+++ b/python/frameworks/openai/traceai_openai/_span_io_handler.py
@@ -51,21 +51,22 @@ def _process_input_data(input_data: Any, span: _WithSpan) -> None:
                     input_content.append(msg)
                     eval_input.append(msg_content)
         if input_content:
-            input_value = json.dumps(input_content, ensure_ascii=False)
-            span.set_attribute(SpanAttributes.INPUT_VALUE, input_value)
+            input_raw = json.dumps(input_content, ensure_ascii=False)
+            span.set_attribute(SpanAttributes.INPUT_RAW, input_raw)
         if input_images:
             images_value = json.dumps(input_images, ensure_ascii=False)
             span.set_attribute(SpanAttributes.INPUT_IMAGES, images_value)
         if eval_input:
             eval_input_str = " \n ".join(map(str, eval_input))
             span.set_attribute(SpanAttributes.INPUT_VALUE, eval_input_str)
-        if eval_input and len(eval_input) > 0:
-            span.set_attribute(SpanAttributes.INPUT_VALUE, eval_input[0])
     else:
-        try:
-            input_str = json.dumps(input_data, ensure_ascii=False).strip()
-        except (TypeError, ValueError):
-            input_str = str(input_data).strip()
+        if isinstance(input_data, str):
+            input_str = input_data.strip()
+        else:
+            try:
+                input_str = json.dumps(input_data, ensure_ascii=False).strip()
+            except (TypeError, ValueError):
+                input_str = str(input_data).strip()
         span.set_attribute(SpanAttributes.INPUT_VALUE, input_str)
 
 

--- a/python/tests/test_framework_openai.py
+++ b/python/tests/test_framework_openai.py
@@ -290,4 +290,79 @@ class TestOpenAIFramework:
         
         # Methods should be restored (back to functions)
         assert openai.OpenAI.request == original_request
-        assert openai.AsyncOpenAI.request == original_async_request 
+        assert openai.AsyncOpenAI.request == original_async_request
+
+
+class TestSpanIOHandler:
+    """Test the span I/O handler functions."""
+
+    def test_process_input_data_multi_message(self):
+        """Test _process_input_data with multiple messages preserves full context."""
+        from traceai_openai._span_io_handler import _process_input_data
+        from fi_instrumentation.fi_types import SpanAttributes
+        from unittest.mock import MagicMock
+
+        # Create mock span
+        mock_span = MagicMock()
+
+        # Test input with multiple messages
+        input_data = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "How are you?"}
+        ]
+
+        _process_input_data(input_data, mock_span)
+
+        # Verify INPUT_VALUE contains full joined text
+        expected_value = "You are a helpful assistant. \n Hello \n Hi there! \n How are you?"
+        mock_span.set_attribute.assert_any_call(SpanAttributes.INPUT_VALUE, expected_value)
+
+        # Verify INPUT_RAW contains structured JSON
+        import json
+        expected_raw = json.dumps([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "How are you?"}
+        ], ensure_ascii=False)
+        mock_span.set_attribute.assert_any_call(SpanAttributes.INPUT_RAW, expected_raw)
+
+    def test_process_input_data_single_message(self):
+        """Test _process_input_data with single message for regression."""
+        from traceai_openai._span_io_handler import _process_input_data
+        from fi_instrumentation.fi_types import SpanAttributes
+        from unittest.mock import MagicMock
+
+        mock_span = MagicMock()
+
+        input_data = [
+            {"role": "user", "content": "Hello world"}
+        ]
+
+        _process_input_data(input_data, mock_span)
+
+        # Should still set INPUT_VALUE to the single message
+        expected_value = "Hello world"
+        mock_span.set_attribute.assert_any_call(SpanAttributes.INPUT_VALUE, expected_value)
+
+        # And INPUT_RAW
+        import json
+        expected_raw = json.dumps([{"role": "user", "content": "Hello world"}], ensure_ascii=False)
+        mock_span.set_attribute.assert_any_call(SpanAttributes.INPUT_RAW, expected_raw)
+
+    def test_process_input_data_non_list(self):
+        """Test _process_input_data with non-list input (string prompt)."""
+        from traceai_openai._span_io_handler import _process_input_data
+        from fi_instrumentation.fi_types import SpanAttributes
+        from unittest.mock import MagicMock
+
+        mock_span = MagicMock()
+
+        input_data = "What is the capital of France?"
+
+        _process_input_data(input_data, mock_span)
+
+        # Should set INPUT_VALUE to the string
+        mock_span.set_attribute.assert_called_once_with(SpanAttributes.INPUT_VALUE, "What is the capital of France?") 

--- a/python/tests/test_framework_openai.py
+++ b/python/tests/test_framework_openai.py
@@ -319,16 +319,6 @@ class TestSpanIOHandler:
         expected_value = "You are a helpful assistant. \n Hello \n Hi there! \n How are you?"
         mock_span.set_attribute.assert_any_call(SpanAttributes.INPUT_VALUE, expected_value)
 
-        # Verify INPUT_RAW contains structured JSON
-        import json
-        expected_raw = json.dumps([
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "Hello"},
-            {"role": "assistant", "content": "Hi there!"},
-            {"role": "user", "content": "How are you?"}
-        ], ensure_ascii=False)
-        mock_span.set_attribute.assert_any_call(SpanAttributes.INPUT_RAW, expected_raw)
-
     def test_process_input_data_single_message(self):
         """Test _process_input_data with single message for regression."""
         from traceai_openai._span_io_handler import _process_input_data
@@ -346,11 +336,6 @@ class TestSpanIOHandler:
         # Should still set INPUT_VALUE to the single message
         expected_value = "Hello world"
         mock_span.set_attribute.assert_any_call(SpanAttributes.INPUT_VALUE, expected_value)
-
-        # And INPUT_RAW
-        import json
-        expected_raw = json.dumps([{"role": "user", "content": "Hello world"}], ensure_ascii=False)
-        mock_span.set_attribute.assert_any_call(SpanAttributes.INPUT_RAW, expected_raw)
 
     def test_process_input_data_non_list(self):
         """Test _process_input_data with non-list input (string prompt)."""


### PR DESCRIPTION
Fixes #151

## Summary
Fixes an issue where `SpanAttributes.INPUT_VALUE` was overwritten multiple times in `_process_input_data`, with the final assignment reducing it to only the first message.

## Changes
- Set `INPUT_VALUE` only once using full joined input
- Removed overwrite with `eval_input[0]`
- Added tests for multi-message, single-message, and non-list inputs

## Impact
Preserves full input context for multi-message traces, improving trace correctness and observability.

## Testing
- Ran: `PYTHONPATH=frameworks/openai poetry run pytest tests/test_framework_openai.py -v`
- All tests passed (including new test cases)