### PR TITLE
fix(otel): exporter shutdown data loss + thread safety in span processor

### DIFF
--- a/python/fi_instrumentation/otel.py
+++ b/python/fi_instrumentation/otel.py
@@ -5,6 +5,7 @@ import logging
 import os
 import signal
 import sys
+import threading
 import uuid
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
@@ -401,6 +402,7 @@ class SimpleSpanProcessor(_SimpleSpanProcessor):
         transport: Transport = Transport.HTTP,
     ):
         self._active_spans = {}
+        self._shutdown_lock = threading.Lock()
 
         if span_exporter is None:
             if transport == Transport.HTTP:
@@ -437,27 +439,21 @@ class SimpleSpanProcessor(_SimpleSpanProcessor):
     def shutdown(self) -> None:
         """Override shutdown to ensure all active spans get exported"""
         try:
-            # Process any spans that haven't been ended
-            if self._active_spans:
-                print(f"Ending {len(self._active_spans)} active spans during shutdown")
+            with self._shutdown_lock:
+                if self._active_spans:
+                    print(f"Ending {len(self._active_spans)} active spans during shutdown")
+                    active_spans = list(self._active_spans.values())
 
-                # Create a copy to avoid modification during iteration
-                active_spans = list(self._active_spans.values())
+                    for span in active_spans:
+                        if hasattr(span, "is_recording") and span.is_recording():
+                            try:
+                                span.set_attribute("gen_ai.span.leaked", True)
+                                span.end()
+                            except Exception:
+                                pass
 
-                # End all active spans and mark them as leaked
-                for span in active_spans:
-                    if hasattr(span, "is_recording") and span.is_recording():
-                        try:
-                            # Mark the span as leaked
-                            span.set_attribute("gen_ai.span.leaked", True)
-                            span.end()
-                        except Exception as e:
-                            pass
-
-                # Clear the tracking dictionary
-                self._active_spans.clear()
+                    self._active_spans.clear()
         finally:
-            # Call the parent shutdown method
             super().shutdown()
 
 

--- a/python/fi_instrumentation/otel.py
+++ b/python/fi_instrumentation/otel.py
@@ -568,6 +568,8 @@ class GRPCSpanExporter(_GRPCSpanExporter):
                 self._session.close()
         except Exception as e:
             print(f"Error during shutdown: {e}")
+        finally:
+            super().shutdown()
 
 
 class HTTPSpanExporter(_HTTPSpanExporter):
@@ -609,6 +611,8 @@ class HTTPSpanExporter(_HTTPSpanExporter):
                 self._session.close()
         except Exception as e:
             print(f"Error during shutdown: {e}")
+        finally:
+            super().shutdown()
 
 
 def _exporter_transport(exporter: SpanExporter) -> str:

--- a/python/fi_instrumentation/otel.py
+++ b/python/fi_instrumentation/otel.py
@@ -441,7 +441,7 @@ class SimpleSpanProcessor(_SimpleSpanProcessor):
         try:
             with self._shutdown_lock:
                 if self._active_spans:
-                    print(f"Ending {len(self._active_spans)} active spans during shutdown")
+                    logger.warning("Ending %d active spans during shutdown", len(self._active_spans))
                     active_spans = list(self._active_spans.values())
 
                     for span in active_spans:
@@ -563,7 +563,7 @@ class GRPCSpanExporter(_GRPCSpanExporter):
             if hasattr(self, "_session") and self._session:
                 self._session.close()
         except Exception as e:
-            print(f"Error during shutdown: {e}")
+            logger.error("Error during gRPC exporter shutdown: %s", e)
         finally:
             super().shutdown()
 
@@ -606,7 +606,7 @@ class HTTPSpanExporter(_HTTPSpanExporter):
             if hasattr(self, "_session") and self._session:
                 self._session.close()
         except Exception as e:
-            print(f"Error during shutdown: {e}")
+            logger.error("Error during HTTP exporter shutdown: %s", e)
         finally:
             super().shutdown()
 


### PR DESCRIPTION
## What does this PR do?

Fixes the exporter shutdown bug and thread safety issue from #164.

- `GRPCSpanExporter.shutdown()` and `HTTPSpanExporter.shutdown()` now call `super().shutdown()` after closing the session, so the parent flushes buffered spans
- `SimpleSpanProcessor.shutdown()` takes a lock around the snapshot + clear of `_active_spans` (per @JayaSurya-27's review -- hot path stays lock-free, dict ops are atomic under GIL)
- swapped `print()` to `logger.warning`/`logger.error` in the shutdown methods since the module logger already exists

## Why?

The missing `super().shutdown()` drops pending spans on process exit. Hits any k8s pod doing graceful shutdown.

Fixes #164 (findings 2, 4, partially 5)

## How was it tested?

- [x] `pytest tests/test_config.py tests/test_init.py tests/test_tracers.py` -- 67 passed, no regressions
- [x] verified via `inspect.getsource()` that both exporters call `super().shutdown()`
- [ ] Integration tests pass (or N/A -- no gateway behavior changed)

`test_otel.py` has a pre-existing import error (`SESSION_NAME` removed) unrelated to this change.

## Checklist

- [x] Branch is off `main`
- [x] Commit messages follow Conventional Commits
- [x] No TODOs or commented-out code
- [x] No API keys or secrets in the diff

## Notes for reviewers

three commits, easy to review individually. lock placement follows @JayaSurya-27's suggestion from the issue thread.

cc @JayaSurya-27