### PR TITLE
fix(mastra): align @traceai/mastra with Mastra 1.32 observability API

### DIFF
--- a/typescript/packages/traceai_mastra/README.md
+++ b/typescript/packages/traceai_mastra/README.md
@@ -1,38 +1,53 @@
 # TraceAI Mastra
+
 ## Installation
 
 ```shell
-npm install --save @traceai/mastra
+npm install --save @traceai/mastra @mastra/observability @mastra/otel-exporter
 ```
 
 ## Usage
 
+`@traceai/mastra` exposes `FITraceExporter`, an OpenTelemetry `SpanExporter`
+that decorates each span with Future AGI semantic attributes and ships it to
+the FI ingest endpoint.
+
+In Mastra 1.32+, custom telemetry is wired through the `observability` field
+on `Mastra`, and a custom OTel `SpanExporter` is plugged into the official
+`@mastra/otel-exporter`. The Mastra runtime converts its internal spans to
+OpenTelemetry `ReadableSpan`s first; `FITraceExporter` then runs its FI
+attribute decoration on those spans before the OTLP export.
+
 ```typescript
 import { Mastra } from "@mastra/core";
-import {
-  FiOTLPTraceExporter,
-  isFiSpan,
-} from "@traceai/mastra";
+import { Observability } from "@mastra/observability";
+import { OtelExporter } from "@mastra/otel-exporter";
+import { FITraceExporter, isFISpan } from "@traceai/mastra";
 
 export const mastra = new Mastra({
-  // ... other config
-  telemetry: {
-    serviceName: "traceai-mastra-agent", // you can rename this to whatever you want to appear in the Phoenix UI
-    enabled: true,
-    export: {
-      type: "custom",
-      exporter: new FiOTLPTraceExporter({
-        url: process.env.PHOENIX_COLLECTOR_ENDPOINT,
-        headers: {
-          Authorization: `Bearer ${process.env.PHOENIX_API_KEY}`,
-        },
-        // optional: filter out http, and other node service specific spans
-        // they will still be exported to Mastra, but not to the target of
-        // this exporter
-        spanFilter: isFiSpan,
-      }),
+  // ...other config
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: "traceai-mastra-agent", // appears as the project name in Future AGI
+        exporters: [
+          new OtelExporter({
+            exporter: new FITraceExporter({
+              url: "https://api.futureagi.com/tracer/v1/traces",
+              headers: {
+                "x-api-key": process.env.FI_API_KEY,
+                "x-secret-key": process.env.FI_SECRET_KEY,
+              },
+              // optional: drop spans that did not receive an FI span kind
+              // (e.g. raw HTTP / framework spans). Spans are still emitted
+              // to other Mastra exporters, just not to Future AGI.
+              spanFilter: isFISpan,
+            }),
+          }),
+        ],
+      },
     },
-  },
+  }),
 });
 ```
 
@@ -40,52 +55,50 @@ export const mastra = new Mastra({
 
 ### Weather Agent
 
-To setup the canonical Mastra weather agent example, and then ingest the spans into TraceAI (or any other OpenInference-compatible platform), follow the steps below.
+To run the canonical Mastra weather agent example and ingest the spans into
+Future AGI (or any other OpenInference-compatible platform):
 
-- Create a new Mastra project
-
-- Add the FiOTLPTraceExporter to your Mastra project
+- Create a new Mastra project.
+- Wire `FITraceExporter` into the project's `observability` config:
 
 ```typescript
 // chosen-project-name/src/index.ts
 import { Mastra } from "@mastra/core/mastra";
-import { createLogger } from "@mastra/core/logger";
+import { PinoLogger } from "@mastra/loggers";
 import { LibSQLStore } from "@mastra/libsql";
-import {
-  isFiSpan,
-  FiOTLPTraceExporter,
-} from "@traceai/mastra";
+import { Observability } from "@mastra/observability";
+import { OtelExporter } from "@mastra/otel-exporter";
+import { FITraceExporter, isFISpan } from "@traceai/mastra";
 
 import { weatherAgent } from "./agents";
 
 export const mastra = new Mastra({
   agents: { weatherAgent },
-  storage: new LibSQLStore({
-    url: ":memory:",
-  }),
-  logger: createLogger({
-    name: "Mastra",
-    level: "info",
-  }),
-  telemetry: {
-    enabled: true,
-    serviceName: "weather-agent",
-    export: {
-      type: "custom",
-      exporter: new FiOTLPTraceExporter({
-        url: "https://api.futureagi.com/tracer/v1/traces",
-        headers: {
-          "x-api-key": process.env.FI_API_KEY,
-          "x-secret-key": process.env.FI_SECRET_KEY,
-        },
-        spanFilter: isFiSpan,
-      }),
+  storage: new LibSQLStore({ url: ":memory:" }),
+  logger: new PinoLogger({ name: "Mastra", level: "info" }),
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: "weather-agent",
+        exporters: [
+          new OtelExporter({
+            exporter: new FITraceExporter({
+              url: "https://api.futureagi.com/tracer/v1/traces",
+              headers: {
+                "x-api-key": process.env.FI_API_KEY!,
+                "x-secret-key": process.env.FI_SECRET_KEY!,
+              },
+              spanFilter: isFISpan,
+            }),
+          }),
+        ],
+      },
     },
-  },
+  }),
 });
 ```
 
-- Run the agent
+- Run the agent:
 
 ```shell
 npm run dev

--- a/typescript/packages/traceai_mastra/package.json
+++ b/typescript/packages/traceai_mastra/package.json
@@ -45,6 +45,9 @@
     "vitest": "^3.1.3"
   },
   "peerDependencies": {
+    "@mastra/core": ">=1.32.0",
+    "@mastra/observability": ">=1.11.0",
+    "@mastra/otel-exporter": ">=1.0.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.0.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.201.1",

--- a/typescript/packages/traceai_mastra/src/attributes.ts
+++ b/typescript/packages/traceai_mastra/src/attributes.ts
@@ -1,76 +1,201 @@
 import {
   FISpanKind,
+  MimeType,
   SemanticConventions,
 } from "@traceai/fi-semantic-conventions";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 
-const MASTRA_AGENT_SPAN_NAME_PREFIXES = [
-  "agent",
-  "mastra.getAgent",
-  "post /api/agents",
-];
+const MASTRA_SPAN_TYPE_ATTR = "mastra.span.type";
 
-/**
- * Add the FI span kind to the given Mastra span.
- *
- * This function will add the FI span kind to the given Mastra span.
- */
-const addFISpanKind = (
-  span: ReadableSpan,
-  kind: FISpanKind,
-) => {
-  span.attributes[SemanticConventions.FI_SPAN_KIND] = kind;
+// Keys @mastra/otel-exporter writes during Mastra → OTel conversion.
+const GEN_AI_INPUT_MESSAGES = "gen_ai.input.messages";
+const GEN_AI_OUTPUT_MESSAGES = "gen_ai.output.messages";
+const GEN_AI_TOOL_CALL_ARGUMENTS = "gen_ai.tool.call.arguments";
+const GEN_AI_TOOL_CALL_RESULT = "gen_ai.tool.call.result";
+const GEN_AI_TOOL_NAME = "gen_ai.tool.name";
+
+const MASTRA_SPAN_TYPE_TO_FI_KIND: Record<string, FISpanKind> = {
+  agent_run: FISpanKind.AGENT,
+  tool_call: FISpanKind.TOOL,
+  mcp_tool_call: FISpanKind.TOOL,
+  model_generation: FISpanKind.LLM,
+  model_step: FISpanKind.LLM,
+  model_chunk: FISpanKind.LLM,
+  scorer_run: FISpanKind.EVALUATOR,
+  scorer_step: FISpanKind.EVALUATOR,
+  workflow_run: FISpanKind.CHAIN,
+  workflow_step: FISpanKind.CHAIN,
+  workflow_conditional: FISpanKind.CHAIN,
+  workflow_conditional_eval: FISpanKind.CHAIN,
+  workflow_parallel: FISpanKind.CHAIN,
+  workflow_loop: FISpanKind.CHAIN,
+  workflow_sleep: FISpanKind.CHAIN,
+  workflow_wait_event: FISpanKind.CHAIN,
+  processor_run: FISpanKind.CHAIN,
+  rag_embedding: FISpanKind.EMBEDDING,
+  rag_vector_operation: FISpanKind.VECTOR_DB,
+  rag_action: FISpanKind.RETRIEVER,
+  rag_ingestion: FISpanKind.CHAIN,
+  graph_action: FISpanKind.CHAIN,
+  memory_operation: FISpanKind.CHAIN,
+  workspace_action: FISpanKind.TOOL,
+  generic: FISpanKind.CHAIN,
 };
 
-/**
- * Get the FI span kind for the given Mastra span.
- *
- * This function will return the FI span kind for the given Mastra span, if it has already been set.
- */
-const getFISpanKind = (span: ReadableSpan) => {
-  return span.attributes[SemanticConventions.FI_SPAN_KIND] as
-    | FISpanKind
-    | undefined;
-};
-
-/**
- * Get the closest FI span kind for the given Mastra span.
- *
- * This function will attempt to detect the closest FI span kind for the given Mastra span,
- * based on the span's name and parent span ID.
- */
-const getFISpanKindFromMastraSpan = (
-  span: ReadableSpan,
-): FISpanKind | null => {
-  const oiKind = getFISpanKind(span);
-  if (oiKind) {
-    return oiKind;
+const safeJsonStringify = (obj: unknown): string => {
+  try {
+    return JSON.stringify(obj);
+  } catch {
+    return String(obj);
   }
-  const spanName = span.name.toLowerCase();
-  if (
-    MASTRA_AGENT_SPAN_NAME_PREFIXES.some((prefix) =>
-      spanName.startsWith(prefix),
-    )
-  ) {
-    return FISpanKind.AGENT;
+};
+
+const safeJsonParse = (value: unknown): unknown => {
+  if (typeof value !== "string") return undefined;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
   }
-  return null;
+};
+
+const isValidJsonString = (value: unknown): boolean => {
+  const parsed = safeJsonParse(value);
+  return typeof parsed === "object" && parsed !== null;
+};
+
+const getMimeTypeFromValue = (value: unknown): MimeType =>
+  isValidJsonString(value) ? MimeType.JSON : MimeType.TEXT;
+
+const setIfMissing = (
+  span: ReadableSpan,
+  key: string,
+  value: unknown,
+): void => {
+  if (value === undefined || value === null) return;
+  if (span.attributes[key] !== undefined) return;
+  span.attributes[key] = value as never;
+};
+
+const setIOValue = (
+  span: ReadableSpan,
+  isInput: boolean,
+  value: unknown,
+): void => {
+  if (value === undefined || value === null) return;
+  const valueKey = isInput
+    ? SemanticConventions.INPUT_VALUE
+    : SemanticConventions.OUTPUT_VALUE;
+  const mimeKey = isInput
+    ? SemanticConventions.INPUT_MIME_TYPE
+    : SemanticConventions.OUTPUT_MIME_TYPE;
+  const asString = typeof value === "string" ? value : safeJsonStringify(value);
+  setIfMissing(span, valueKey, asString);
+  setIfMissing(span, mimeKey, getMimeTypeFromValue(asString));
 };
 
 /**
- * Enrich a Mastra span with FI attributes.
- *
- * This function will add additional attributes to the span, based on the Mastra span's attributes.
- *
- * It will attempt to detect the closest FI span kind for the given Mastra span, and then
- * enrich the span with the appropriate attributes based on the span kind and current attributes.
- *
- * @param span - The Mastra span to enrich.
+ * Extract a plain-text summary from a Mastra agent_run output payload.
+ * Mastra emits agent_run output as `{ "files": [...], "text": "..." }`;
+ * the dashboard's OUTPUT_VALUE looks best as the unwrapped text.
+ */
+const extractAgentOutputText = (raw: unknown): string | undefined => {
+  const parsed = typeof raw === "string" ? safeJsonParse(raw) : raw;
+  if (parsed && typeof parsed === "object" && "text" in parsed) {
+    const text = (parsed as { text?: unknown }).text;
+    if (typeof text === "string" && text.length > 0) return text;
+  }
+  return undefined;
+};
+
+/**
+ * Map Mastra's `mastra.span.type` to FI's span kind, and copy
+ * inputs/outputs/tool info onto FI's canonical attribute keys so the
+ * Future AGI dashboard renders them in the Input/Output/Tool panels.
  */
 export const addFIAttributesToMastraSpan = (span: ReadableSpan) => {
-  const kind = getFISpanKindFromMastraSpan(span);
-  if (kind) {
-    addFISpanKind(span, kind);
+  const mastraType = span.attributes[MASTRA_SPAN_TYPE_ATTR];
+  if (typeof mastraType !== "string") return;
+
+  if (!span.attributes[SemanticConventions.FI_SPAN_KIND]) {
+    const kind = MASTRA_SPAN_TYPE_TO_FI_KIND[mastraType];
+    if (kind) span.attributes[SemanticConventions.FI_SPAN_KIND] = kind;
   }
-  // TODO: Further enrich the span with additional attributes based on the span kind
+
+  const attrs = span.attributes;
+  const spanTypeKey = mastraType.toLowerCase();
+  const rawInput = attrs[`mastra.${spanTypeKey}.input`];
+  const rawOutput = attrs[`mastra.${spanTypeKey}.output`];
+
+  switch (mastraType) {
+    case "agent_run": {
+      setIOValue(span, true, rawInput);
+      if (rawOutput !== undefined) {
+        setIfMissing(
+          span,
+          SemanticConventions.RAW_OUTPUT,
+          typeof rawOutput === "string" ? rawOutput : safeJsonStringify(rawOutput),
+        );
+        const text = extractAgentOutputText(rawOutput);
+        if (text !== undefined) {
+          setIOValue(span, false, text);
+        } else {
+          setIOValue(span, false, rawOutput);
+        }
+      }
+      break;
+    }
+
+    case "tool_call":
+    case "mcp_tool_call": {
+      const toolName = attrs[GEN_AI_TOOL_NAME];
+      if (typeof toolName === "string") {
+        setIfMissing(span, SemanticConventions.TOOL_NAME, toolName);
+      }
+      setIOValue(span, true, attrs[GEN_AI_TOOL_CALL_ARGUMENTS] ?? rawInput);
+      setIOValue(span, false, attrs[GEN_AI_TOOL_CALL_RESULT] ?? rawOutput);
+      break;
+    }
+
+    case "model_generation":
+    case "model_step":
+    case "model_chunk": {
+      // Tokens (gen_ai.usage.*), model (gen_ai.request.model), and messages
+      // (gen_ai.input.messages / gen_ai.output.messages) are already on the
+      // FI canonical keys — no remapping needed. Expose RAW_INPUT/RAW_OUTPUT
+      // and MIME types so the dashboard renders the LLM panel.
+      const inputMessages = attrs[GEN_AI_INPUT_MESSAGES];
+      const outputMessages = attrs[GEN_AI_OUTPUT_MESSAGES];
+      if (inputMessages !== undefined) {
+        setIfMissing(
+          span,
+          SemanticConventions.RAW_INPUT,
+          typeof inputMessages === "string"
+            ? inputMessages
+            : safeJsonStringify(inputMessages),
+        );
+        setIfMissing(span, SemanticConventions.INPUT_MIME_TYPE, MimeType.JSON);
+      }
+      if (outputMessages !== undefined) {
+        setIfMissing(
+          span,
+          SemanticConventions.RAW_OUTPUT,
+          typeof outputMessages === "string"
+            ? outputMessages
+            : safeJsonStringify(outputMessages),
+        );
+        setIfMissing(span, SemanticConventions.OUTPUT_MIME_TYPE, MimeType.JSON);
+      }
+      // Fallback for spans where Mastra wrote mastra.<type>.input/.output too.
+      setIOValue(span, true, rawInput);
+      setIOValue(span, false, rawOutput);
+      break;
+    }
+
+    default: {
+      setIOValue(span, true, rawInput);
+      setIOValue(span, false, rawOutput);
+      break;
+    }
+  }
 };

--- a/typescript/packages/traceai_mastra/src/utils.ts
+++ b/typescript/packages/traceai_mastra/src/utils.ts
@@ -1,35 +1,39 @@
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
-import {
-  SemanticConventions,
-  ATTR_PROJECT_NAME,
-} from "@traceai/fi-semantic-conventions";
+import { SemanticConventions } from "@traceai/fi-semantic-conventions";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 
+// FI ingestion (fi-core) reads these as raw, un-namespaced resource attribute
+// keys. They must be present for traces to be bucketed into a project on the
+// Future AGI dashboard.
+const FI_RESOURCE_PROJECT_NAME = "project_name";
+const FI_RESOURCE_PROJECT_TYPE = "project_type";
+const FI_PROJECT_TYPE_OBSERVE = "observe";
+
 /**
- * Augments a span with OpenInference project resource attribute.
- *
- * This function will add additional attributes to the span, based on the span's resource attributes.
- *
- * @param span - The span to augment.
+ * Ensure the resource carries the FI-required project_name + project_type
+ * attributes. Without project_type set, the FI dashboard accepts the trace
+ * but won't surface it under any project.
  */
-export const addFIProjectResourceAttributeSpan = (
-  span: ReadableSpan,
-) => {
-  const attributes = span.resource.attributes;
-  if (ATTR_SERVICE_NAME in attributes) {
-    attributes[ATTR_PROJECT_NAME] = attributes[ATTR_SERVICE_NAME];
+export const addFIProjectResourceAttributeSpan = (span: ReadableSpan) => {
+  const attributes = span.resource.attributes as Record<string, unknown>;
+  if (
+    ATTR_SERVICE_NAME in attributes &&
+    !(FI_RESOURCE_PROJECT_NAME in attributes)
+  ) {
+    attributes[FI_RESOURCE_PROJECT_NAME] = attributes[ATTR_SERVICE_NAME];
+  }
+  if (!(FI_RESOURCE_PROJECT_TYPE in attributes)) {
+    attributes[FI_RESOURCE_PROJECT_TYPE] = FI_PROJECT_TYPE_OBSERVE;
   }
 };
 
 /**
- * Determines whether a span is an OpenInference span.
+ * Determines whether a span carries an FI span kind attribute.
  *
  * @param span - The span to check.
- * @returns `true` if the span is an OpenInference span, `false` otherwise.
+ * @returns `true` if the span has `fi.span.kind` set, `false` otherwise.
  */
 export const isFISpan = (span: ReadableSpan) => {
-  const maybeFISpanKind =
-    span.attributes[SemanticConventions.FI_SPAN_KIND];
+  const maybeFISpanKind = span.attributes[SemanticConventions.FI_SPAN_KIND];
   return typeof maybeFISpanKind === "string";
 };
-


### PR DESCRIPTION
## Summary

`@traceai/mastra` was built against the pre-1.0 Mastra telemetry surface (`telemetry: { export: { type: "custom", exporter } }`). Mastra 1.32 dropped that field in favor of `observability: new Observability({ configs })` from `@mastra/observability`, and custom exporters no longer receive OTel `ReadableSpan`s directly — they receive Mastra `TracingEvent`s, with `@mastra/otel-exporter` doing the Mastra → OTel conversion via `SpanConverter`. The fix wires `FITraceExporter` in as the OTel `SpanExporter` that `OtelExporter` delegates to, and adapts the post-conversion attribute decoration to Mastra's new span shape so the Future AGI dashboard renders the trace correctly.

## What changed

- **`src/attributes.ts`** — derive `fi.span.kind` from `mastra.span.type` across every Mastra `SpanType` (agent_run, tool_call, model_*, workflow_*, rag_*, scorer_*, etc.) instead of name-prefix heuristics. Map Mastra / gen_ai I/O attrs onto FI canonical keys (`input.value`, `output.value`, `tool.name`, `raw.input`, `raw.output`): unwrap `.text` from `agent_run` output (matching `traceai_openai_agents`' `getTextFromResponse` pattern), copy `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` for tool spans, surface `gen_ai.input.messages` / `gen_ai.output.messages` on model spans. MIME detection follows `@traceai/vercel`'s pattern (JSON if parseable, else text).
- **`src/utils.ts`** — write raw `project_name` and `project_type=observe` on the resource (matches `fi-core`'s `register()`). Previously the package wrote `fi.project.name` from `@traceai/fi-semantic-conventions`, which the FI ingest does not read; traces were accepted but never bucketed into a project on the dashboard.
- **`package.json`** — add `@mastra/core`, `@mastra/observability`, `@mastra/otel-exporter` as peer deps.
- **`README.md`** — replace the obsolete `telemetry` usage with the new `observability: new Observability({ configs: { default: { exporters: [new OtelExporter({ provider, exporter: new FITraceExporter(...) })] } } })` wiring, including the `provider: { custom: ... }` passthrough that `OtelExporter` validates even when a custom `exporter` is supplied.

## Resulting data flow

Mastra `TracingEvent` → `OtelExporter` (Mastra → OTel via `SpanConverter`, adds `mastra.span.type` + `gen_ai.*` attrs) → `BatchSpanProcessor` → `FITraceExporter.export()` (sets `project_name` / `project_type` on the resource, `fi.span.kind` per Mastra `SpanType`, `input.value` / `output.value` / `tool.name` / `raw.*` per span kind, MIME types) → OTLP/protobuf → Future AGI Observe.

## Test plan

- [x] `pnpm --filter @traceai/mastra build` succeeds (no TS errors).
- [x] End-to-end smoke test against `@mastra/core@1.32.1` with an Agent that calls a tool, traced through `Observability` → `OtelExporter` → `FITraceExporter` → `api.futureagi.com/tracer/v1/traces`. OTLP export returns `code: 0`.
- [x] Trace appears under **Observe** with the expected tree: `invoke_agent` (AGENT) → `chat <model>` (LLM/MODEL_GENERATION) → `model_step` (LLM) + `execute_tool` (TOOL) → `model_step` (LLM).
- [x] Dashboard panels populate: agent root shows the user prompt as `input.value`, the unwrapped assistant text as `output.value`, full `{files, text}` payload in `raw.output`; tool span shows `tool.name`, arguments as `input.value`, result as `output.value`; model spans carry `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` (= FI's `LLM_TOKEN_COUNT_*`).