### PR TITLE
fix(crewai): make traceai_crewai instrumentor compatible with crewai 1.x

### DIFF
--- a/python/frameworks/crewai/traceai_crewai/_wrappers.py
+++ b/python/frameworks/crewai/traceai_crewai/_wrappers.py
@@ -11,6 +11,20 @@ from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.util.types import AttributeValue
 
+# In crewai 1.x `i18n` is no longer an attribute on `Agent`; it's a module-level
+# singleton. Older crewai versions still expose `agent.i18n`, so we try the
+# attribute first and fall back to the singleton when it's missing.
+try:
+    from crewai.utilities.i18n import I18N_DEFAULT as _I18N_DEFAULT
+except ImportError:  # pragma: no cover - very old crewai path
+    _I18N_DEFAULT = None  # type: ignore[assignment]
+
+
+def _agent_i18n_prompt_file(agent: Any) -> Any:
+    """Return the agent's i18n prompt_file across crewai 0.x/1.x layouts."""
+    i18n = getattr(agent, "i18n", None) or _I18N_DEFAULT
+    return getattr(i18n, "prompt_file", None) if i18n is not None else None
+
 
 class SafeJSONEncoder(json.JSONEncoder):
     """
@@ -224,7 +238,7 @@ class _KickoffWrapper:
                             "verbose?": agent.verbose,
                             "max_iter": agent.max_iter,
                             "max_rpm": agent.max_rpm,
-                            "i18n": agent.i18n.prompt_file,
+                            "i18n": _agent_i18n_prompt_file(agent),
                             "delegation_enabled": agent.allow_delegation,
                             "tools_names": [
                                 tool.name.casefold() for tool in agent.tools or []
@@ -246,9 +260,12 @@ class _KickoffWrapper:
                             "human_input?": task.human_input,
                             "agent_role": task.agent.role if task.agent else "None",
                             "agent_key": task.agent.key if task.agent else None,
+                            # crewai 1.x defaults `Task.context` to a
+                            # `_NotSpecified` sentinel (truthy but not
+                            # iterable), so guard with an isinstance check.
                             "context": (
-                                [task.description for task in task.context]
-                                if task.context
+                                [t.description for t in task.context]
+                                if isinstance(task.context, list)
                                 else None
                             ),
                             "tools_names": [
@@ -262,6 +279,9 @@ class _KickoffWrapper:
             try:
                 crew_output = wrapped(*args, **kwargs)
                 usage_metrics = crew.usage_metrics
+                # crewai 1.x returns a `CrewStreamingOutput` immediately when
+                # `crew.stream=True`; usage metrics aren't populated yet in
+                # that case. Guard so streaming runs don't crash the wrapper.
                 if isinstance(usage_metrics, dict):
                     if (
                         prompt_tokens := usage_metrics.get("prompt_tokens")
@@ -275,7 +295,7 @@ class _KickoffWrapper:
                         )
                     if (total_tokens := usage_metrics.get("total_tokens")) is not None:
                         span.set_attribute(GEN_AI_USAGE_TOTAL_TOKENS, int(total_tokens))
-                else:
+                elif usage_metrics is not None:
                     # version 0.51 and onwards
                     span.set_attribute(
                         GEN_AI_USAGE_INPUT_TOKENS, usage_metrics.prompt_tokens
@@ -294,8 +314,10 @@ class _KickoffWrapper:
                 span.record_exception(exception)
                 raise
             span.set_status(trace_api.StatusCode.OK)
-            if crew_output_dict := crew_output.to_dict():
-
+            # `CrewStreamingOutput` (crewai 1.x stream=True) has no `to_dict`.
+            to_dict = getattr(crew_output, "to_dict", None)
+            crew_output_dict = to_dict() if callable(to_dict) else None
+            if crew_output_dict:
                 span.set_attribute(OUTPUT_VALUE, json.dumps(crew_output_dict))
                 span.set_attribute(OUTPUT_MIME_TYPE, "application/json")
             else:


### PR DESCRIPTION
## Summary

`traceai_crewai` was written against crewai 0.4x. With the instrumentor installed on a host application that has upgraded to **crewai 1.x**, `Crew.kickoff()` raises *before reaching the wrapped call* — so the entire crew workflow fails the moment tracing is enabled. This PR fixes the two hard 1.x crashes plus two latent issues that surface on streaming kickoffs (`crew.stream=True`), with the minimum diff necessary. All four changes preserve behavior on the older crewai versions the package already supported.

Verified end to end against **crewai 1.14.4**: instrumented `Crew.kickoff` ran cleanly, spans shipped to Future AGI Observe, agent run + task execute spans rendered with usage tokens (prompt 99 / completion 20 / total 119).

## What was breaking on crewai 1.x

### 1. `agent.i18n.prompt_file` no longer exists — crashes every `Crew.kickoff()`

In crewai 1.x, `i18n` was demoted from an `Agent` field to a module-level singleton `I18N_DEFAULT` exposed by `crewai.utilities.i18n`. The wrapper's ``crew_agents`` dict-comp reads ``agent.i18n.prompt_file`` for every agent in ``crew.agents``, which raises ``AttributeError``. Because the surrounding span block sets ``record_exception=False, set_status_on_exception=False``, the exception propagates out before ``wrapped()`` ever runs. Effect: every `Crew.kickoff()` call crashes the moment ``CrewAIInstrumentor().instrument()`` is called.

### 2. `Task.context` defaults to `_NotSpecified`, not `None` — crashes every `Crew.kickoff()`

In crewai 1.x ``Task.context`` is typed ``list[Task] | None | _NotSpecified`` and defaults to the sentinel. The wrapper's ``if task.context else None`` truthiness check passes for the truthy sentinel, then the list-comp ``[task.description for task in task.context]`` raises ``TypeError: '_NotSpecified' object is not iterable``. Same crash surface as (1) — happens before ``wrapped()`` runs.

### 3. `crew.usage_metrics` can be `None` on streaming kickoffs

With ``crew.stream=True``, crewai 1.x returns a ``CrewStreamingOutput`` immediately and never reaches ``self.usage_metrics = self.calculate_usage_metrics()`` inside ``Crew.kickoff`` before returning. The wrapper's existing ``else`` branch then reads ``usage_metrics.prompt_tokens`` on ``None`` and raises ``AttributeError``.

### 4. `CrewStreamingOutput` has no `to_dict()`

The wrapper's ``if crew_output_dict := crew_output.to_dict():`` raises ``AttributeError`` when streaming returns the streaming-output wrapper instead of a ``CrewOutput``.

## What this patch changes

All scoped to ``python/frameworks/crewai/traceai_crewai/_wrappers.py``:

- **`agent.i18n.prompt_file` → safe helper.** Added a small `_agent_i18n_prompt_file(agent)` that prefers ``agent.i18n`` (older crewai) and falls back to the ``crewai.utilities.i18n.I18N_DEFAULT`` singleton (1.x). The `I18N_DEFAULT` import is wrapped in `try/except ImportError` so the package still loads on very old crewai where the singleton path doesn't exist.

- **`Task.context` truthiness → `isinstance(list)` guard.** Now ``[t.description for t in task.context] if isinstance(task.context, list) else None``. Also renames the inner loop variable from `task` to `t` so it stops shadowing the outer `task` in the surrounding comprehension — a latent bug that was just masked by the earlier crash.

- **`else:` → `elif usage_metrics is not None:`.** Streaming runs skip the object branch instead of crashing on `None.prompt_tokens`. The earlier `isinstance(usage_metrics, dict)` branch is unchanged.

- **Walrus on `crew_output.to_dict()` → `getattr` + `callable` guard.** ``to_dict = getattr(crew_output, 'to_dict', None); crew_output_dict = to_dict() if callable(to_dict) else None`` — falls through to ``str(crew_output)`` when absent.

## What's NOT changed

I deliberately kept the diff to the four 1.x regressions. The following were considered and dropped as out-of-scope:

- ``isinstance(args[0], Agent)`` in ``_get_input_value`` — would degrade for non-`Agent` `BaseAgent` subclasses (LiteAgent, agent adapters), but isn't a crash on a normal CrewAI `Agent`. Future-proofing, not a 1.x regression.
- ``span.set_attribute("function_calling_llm", instance.function_calling_llm)`` — `function_calling_llm` is now an `LLM` object in 1.x, but OTel silently drops non-primitive attribute values. No crash; same behavior as 0.x where it was a LangChain ChatModel.
- A duplicated ``set_attribute(OUTPUT_VALUE, ...)`` line in `_ToolUseWrapper`. Pre-existing dead code, not in scope.
- LLM model / cost capture — by design the CrewAI instrumentor only emits framework spans (`Crew.kickoff`, `Task._execute_core`, `ToolUsage._use`). Model name and cost come from running `OpenAIInstrumentor` (or equivalent provider instrumentor) alongside this one. Same pattern as the other framework instrumentors in this repo.

## Test plan

- [x] `python -m py_compile python/frameworks/crewai/traceai_crewai/_wrappers.py` — syntax clean.
- [x] Fresh venv (Python 3.12) with `crewai==1.14.4`, `fi-instrumentation-otel==1.0.0`, and `traceai-crewai` installed editable from this branch.
- [x] Smoke test: single-agent + single-task Crew, `crew.kickoff()` against OpenAI `gpt-4o-mini`. **Before fix:** crashes with `_NotSpecified` TypeError. **After fix:** runs to completion, returns model output, no exceptions.
- [x] Trace lands in Future AGI Observe under the configured project:
  - `Crew.kickoff` root span: status OK, duration 3.4s, tokens prompt=99 / completion=20 / total=119, `gen_ai.span.kind=CHAIN`, `crew_agents` and `crew_tasks` blobs populated, `crew_tasks[].context = null` (correctly handled `_NotSpecified` sentinel), `crew_agents[].i18n = null` (correctly handled missing field), `output.value` = the agent's generated text.
  - `Task._execute_core` child span present and parented correctly.

## Files changed

- `python/frameworks/crewai/traceai_crewai/_wrappers.py` — 28 insertions, 6 deletions.