### PR TITLE
fix(google-adk): make traceai_google_adk instrumentor compatible with google-adk 1.x

### DIFF
--- a/python/frameworks/google-adk/traceai_google_adk/__init__.py
+++ b/python/frameworks/google-adk/traceai_google_adk/__init__.py
@@ -74,104 +74,169 @@ class GoogleADKInstrumentor(BaseInstrumentor):  # type: ignore
             setattr(parent, attribute, original)
 
     def _patch_trace_call_llm(self) -> None:
-        """Patch the LLM call tracing functionality to use our tracer."""
-        from google.adk.flows.llm_flows import base_llm_flow
+        """Patch the LLM call tracing functionality to use our tracer.
 
+        Prefers patching ``google.adk.telemetry.tracing`` (the source of
+        truth in google-adk >= 1.x where the trace functions were
+        centralized). Falls back to the older
+        ``google.adk.flows.llm_flows.base_llm_flow`` re-export for old
+        google-adk versions where ``telemetry.tracing`` doesn't exist.
+        """
         from traceai_google_adk._wrappers import _TraceCallLlm
 
-        setattr(base_llm_flow, "tracer", self._tracer)
+        target, attr = self._resolve_trace_call_llm_target()
+        if target is None:
+            return
+        setattr(target, "tracer", self._tracer)
         setattr(
-            base_llm_flow,
-            "trace_call_llm",
-            _TraceCallLlm(self._tracer)(base_llm_flow.trace_call_llm),  # type: ignore[attr-defined]
+            target,
+            attr,
+            _TraceCallLlm(self._tracer)(getattr(target, attr)),  # type: ignore[attr-defined]
         )
 
     def _unpatch_trace_call_llm(self) -> None:
         """Restore the original LLM call tracing functionality."""
-        from google.adk.flows.llm_flows import base_llm_flow
+        target, attr = self._resolve_trace_call_llm_target()
+        if target is None:
+            return
+        current = getattr(target, attr, None)
+        if callable(original := getattr(current, "__wrapped__", None)):
+            setattr(target, attr, original)
 
-        if callable(
-            original := getattr(base_llm_flow.trace_call_llm, "__wrapped__"),  # type: ignore[attr-defined]
-        ):
-            from google.adk.flows.llm_flows import (
-                base_llm_flow,
-            )
+        try:
+            from google.adk.telemetry import tracer  # type: ignore[attr-defined]
 
-            setattr(base_llm_flow, "trace_call_llm", original)
+            setattr(target, "tracer", tracer)
+        except ImportError:
+            pass
 
-        from google.adk.telemetry import tracer
+    @staticmethod
+    def _resolve_trace_call_llm_target() -> Tuple[Any, str]:
+        """Return the (module, attr_name) to patch for trace_call_llm.
 
-        setattr(base_llm_flow, "tracer", tracer)
+        google-adk 1.x exposes the canonical definition at
+        ``google.adk.telemetry.tracing``; older versions only re-export
+        it through ``google.adk.flows.llm_flows.base_llm_flow``.
+        """
+        try:
+            from google.adk.telemetry import tracing as adk_tracing
+
+            if hasattr(adk_tracing, "trace_call_llm"):
+                return adk_tracing, "trace_call_llm"
+        except ImportError:
+            pass
+
+        try:
+            from google.adk.flows.llm_flows import base_llm_flow
+
+            if hasattr(base_llm_flow, "trace_call_llm"):
+                return base_llm_flow, "trace_call_llm"
+        except ImportError:
+            pass
+        return None, "trace_call_llm"  # type: ignore[return-value]
 
     def _patch_trace_tool_call(self) -> None:
-        """Patch the tool call tracing functionality to use our tracer."""
-        from google.adk.flows.llm_flows import functions
+        """Patch the tool call tracing functionality to use our tracer.
 
+        In google-adk 1.x the rich per-tool tracing function moved to
+        ``google.adk.telemetry.tracing.trace_tool_call`` (with its
+        original signature). The old patch target
+        ``google.adk.flows.llm_flows.functions.trace_tool_call`` was
+        renamed away, so we prefer the new location and fall back to
+        the old one for compatibility with pre-1.x ADK.
+        """
         from traceai_google_adk._wrappers import _TraceToolCall
 
-        setattr(functions, "tracer", self._tracer)
+        target, attr = self._resolve_trace_tool_call_target()
+        if target is None:
+            return
+        setattr(target, "tracer", self._tracer)
         setattr(
-            functions,
-            "trace_tool_call",
-            _TraceToolCall(self._tracer)(functions.trace_tool_call),  # type: ignore[attr-defined]
+            target,
+            attr,
+            _TraceToolCall(self._tracer)(getattr(target, attr)),  # type: ignore[attr-defined]
         )
 
     def _unpatch_trace_tool_call(self) -> None:
         """Restore the original tool call tracing functionality."""
-        from google.adk.flows.llm_flows.base_llm_flow import functions  # type: ignore[attr-defined]
+        target, attr = self._resolve_trace_tool_call_target()
+        if target is None:
+            return
+        current = getattr(target, attr, None)
+        if callable(original := getattr(current, "__wrapped__", None)):
+            setattr(target, attr, original)
 
-        if callable(
-            original := getattr(functions.trace_tool_call, "__wrapped__"),  # type: ignore[attr-defined]
-        ):
-            from google.adk.flows.llm_flows.base_llm_flow import (  # type: ignore[attr-defined]
-                functions,
-            )
+        try:
+            from google.adk.telemetry import tracer  # type: ignore[attr-defined]
 
-            setattr(functions, "trace_tool_call", original)
+            setattr(target, "tracer", tracer)
+        except ImportError:
+            pass
 
-        from google.adk.telemetry import tracer
+    @staticmethod
+    def _resolve_trace_tool_call_target() -> Tuple[Any, str]:
+        """Return the (module, attr_name) to patch for trace_tool_call.
 
-        setattr(functions, "tracer", tracer)
+        google-adk 1.x keeps the rich-signature ``trace_tool_call`` in
+        ``google.adk.telemetry.tracing`` (called from
+        ``record_tool_execution``). Older ADK had it re-exported from
+        ``google.adk.flows.llm_flows.functions``.
+        """
+        try:
+            from google.adk.telemetry import tracing as adk_tracing
+
+            if hasattr(adk_tracing, "trace_tool_call"):
+                return adk_tracing, "trace_tool_call"
+        except ImportError:
+            pass
+
+        try:
+            from google.adk.flows.llm_flows import functions
+
+            if hasattr(functions, "trace_tool_call"):
+                return functions, "trace_tool_call"
+        except ImportError:
+            pass
+        return None, "trace_tool_call"  # type: ignore[return-value]
 
     def _disable_existing_tracers(self) -> None:
         """Disable existing tracers to prevent double-instrumentation."""
-        from google.adk.runners import (  # type: ignore[attr-defined]
-            tracer,  # pyright: ignore[reportPrivateImportUsage]
-        )
+        from google.adk import runners
 
-        if isinstance(tracer, Tracer):
-            from google.adk import runners
+        if isinstance(getattr(runners, "tracer", None), Tracer):
+            setattr(runners, "tracer", _PassthroughTracer(runners.tracer))
 
-            setattr(runners, "tracer", _PassthroughTracer(tracer))
-
-        from google.adk.agents.base_agent import (
-            tracer,  # pyright: ignore[reportPrivateImportUsage]
-        )
-
-        if isinstance(tracer, Tracer):
+        # google-adk 1.x removed the module-level `tracer` from
+        # base_agent. Guard so the import error doesn't kill instrument().
+        try:
             from google.adk.agents import base_agent
-
-            setattr(base_agent, "tracer", _PassthroughTracer(tracer))
+        except ImportError:
+            base_agent = None  # type: ignore[assignment]
+        if base_agent is not None and isinstance(
+            getattr(base_agent, "tracer", None), Tracer
+        ):
+            setattr(base_agent, "tracer", _PassthroughTracer(base_agent.tracer))
 
     def _restore_existing_tracers(self) -> None:
         """Restore original tracers that were disabled during instrumentation."""
-        from google.adk.runners import (  # type: ignore[attr-defined]
-            tracer,  # pyright: ignore[reportPrivateImportUsage]
-        )
+        from google.adk import runners
 
-        if isinstance(original := getattr(tracer, "__wrapped__"), Tracer):
-            from google.adk import runners
-
+        runners_tracer = getattr(runners, "tracer", None)
+        if isinstance(
+            original := getattr(runners_tracer, "__wrapped__", None), Tracer
+        ):
             setattr(runners, "tracer", original)
 
-        from google.adk.agents.base_agent import (
-            tracer,  # pyright: ignore[reportPrivateImportUsage]
-        )
-
-        if isinstance(original := getattr(tracer, "__wrapped__"), Tracer):
+        try:
             from google.adk.agents import base_agent
-
-            setattr(base_agent, "tracer", original)
+        except ImportError:
+            base_agent = None  # type: ignore[assignment]
+        if base_agent is not None:
+            base_agent_tracer = getattr(base_agent, "tracer", None)
+            if isinstance(
+                original := getattr(base_agent_tracer, "__wrapped__", None), Tracer
+            ):
+                setattr(base_agent, "tracer", original)
 
 
 class _PassthroughTracer(wrapt.ObjectProxy):  # type: ignore[misc]


### PR DESCRIPTION
## Summary

`traceai_google_adk` 0.1.4 was written against an internal layout of `google-adk` that doesn't exist anymore. With the instrumentor installed on **google-adk 1.x** (verified against 1.33.0), `GoogleADKInstrumentor().instrument()` **crashes immediately** — before any agent code runs — because the modules it monkey-patches were restructured. Effect: no spans at all on 1.x.

This PR moves the patch targets to the post-restructure locations, guards the imports of attributes that were removed, and fixes a latent wrong-import in the unpatch path. All four changes are scoped to `__init__.py`; `_wrappers.py` is untouched.

Verified end to end against **google-adk 1.33.0** with `LiteLlm(model=\"openai/gpt-4o-mini\")` and a single weather tool: the full trace tree lands in Future AGI Observe — `invocation` (CHAIN) → `agent_run` (AGENT) → google-adk's own `invoke_agent` → two `generate_content openai/gpt-4o-mini` LLM spans with tokens → `execute_tool get_weather` (TOOL). `user.id` and `gen_ai.conversation.id` populated on the root from runner kwargs.

## What was breaking on google-adk 1.x

### 1. `functions.trace_tool_call` doesn't exist anymore — `AttributeError`, crashes `instrument()`

The wrapper does `setattr(functions, \"trace_tool_call\", ...)` where `functions = google.adk.flows.llm_flows.functions`. That worked when `functions.py` had `from ...telemetry import trace_tool_call` at the top, binding it as a module attribute. In 1.x, that import was renamed to `from ...telemetry.tracing import trace_merged_tool_calls` — a **different function** with a narrower signature `(response_event_id: str, function_response_event: Event)`. So `functions.trace_tool_call` is gone, and the AttributeError kills `_patch_trace_tool_call()` before it can install anything.

The original rich `trace_tool_call(tool, args, function_response_event, error=None, span=None)` is still alive — it just moved to `google.adk.telemetry.tracing.trace_tool_call` and is now called from `google.adk.telemetry._instrumentation.record_tool_execution`. The new module is the right patch target on 1.x: same signature, same call site, so the existing `_TraceToolCall` wrapper (which scans bound args for `BaseTool` / `Mapping` / `Event`) still extracts everything correctly.

### 2. `setattr(<module>, \"tracer\", self._tracer)` is a no-op on 1.x

The wrapper redirects the tracer used by patched functions via `setattr(functions, \"tracer\", ...)` and `setattr(base_llm_flow, \"tracer\", ...)`. In 1.x both `trace_call_llm` and `trace_tool_call` live in `google.adk.telemetry.tracing` and read **that** module's `tracer` — overriding `tracer` on the re-export modules does nothing. The right target on 1.x is `google.adk.telemetry.tracing.tracer`.

### 3. `base_agent.tracer` was removed — `ImportError`, crashes `instrument()`

`_disable_existing_tracers` does `from google.adk.agents.base_agent import tracer`. In 1.x the module-level `tracer` was deleted, so this bare import raises `ImportError` and kills `instrument()` at the next step (after #1 above is fixed). `google.adk.runners.tracer` still exists — only the `base_agent` half was removed.

### 4. Pre-existing latent bug — wrong import path in `_unpatch_trace_tool_call`

`from google.adk.flows.llm_flows.base_llm_flow import functions` — `functions` is a sibling module of `base_llm_flow`, not an attribute of it. This was broken on every ADK version but only fires when `uninstrument()` is called, which masked it.

## What this patch changes

All in `python/frameworks/google-adk/traceai_google_adk/__init__.py`. No changes to `_wrappers.py`.

- **`_patch_trace_tool_call` / `_unpatch_trace_tool_call`** — patch `google.adk.telemetry.tracing.trace_tool_call` instead of `functions.trace_tool_call`. Set `tracing.tracer = self._tracer` so the patched function actually uses our tracer. New `_resolve_trace_tool_call_target` static helper resolves the right module on import — `telemetry.tracing` on 1.x, falls back to `flows.llm_flows.functions` on older ADK. The unpatch path goes through the same helper, eliminating the wrong import.

- **`_patch_trace_call_llm` / `_unpatch_trace_call_llm`** — same treatment. Prefers `telemetry.tracing.trace_call_llm` (which is the source of truth in 1.x), falls back to `base_llm_flow.trace_call_llm` for old ADK via `_resolve_trace_call_llm_target`. Tracer redirect lands on the module that actually uses it.

- **`_disable_existing_tracers` / `_restore_existing_tracers`** — replaced the bare `from ... import tracer` with `getattr(..., \"tracer\", None)` inside a `try/except ImportError` on the module import, so the missing 1.x attribute no longer crashes `instrument()`. `runners.tracer` path unchanged.

## What's NOT changed and why

- **`_wrappers.py` is untouched.** The four wrappers (`_RunnerRunAsync`, `_BaseAgentRunAsync`, `_TraceCallLlm`, `_TraceToolCall`) produce the right span attributes once they're attached to the right call site. The argument-scan in `_TraceToolCall` for `BaseTool` / `Mapping` / `Event` instances still finds them all because `tracing.trace_tool_call` kept the original signature.
- **`Runner.run_async` / `BaseAgent.run_async` method wraps** — still works in 1.x, left alone.
- **`runners.tracer` disable path** — still works, left alone.
- **Version pin** `google-adk >= 1.2.1` and other pyproject metadata — untouched.

## Test plan

- [x] `python -m py_compile python/frameworks/google-adk/traceai_google_adk/__init__.py` — syntax clean.
- [x] Fresh Python 3.12 venv with `google-adk[extensions]==1.33.0`, `fi-instrumentation-otel`, and `traceai-google-adk` installed editable from this branch.
- [x] `GoogleADKInstrumentor().instrument(tracer_provider=...)` returns successfully. **Before fix:** dies with `AttributeError: module 'google.adk.flows.llm_flows.functions' has no attribute 'trace_tool_call'`. **After fix:** clean install.
- [x] Smoke test: `InMemoryRunner` with a `weather_agent` (LiteLlm → `openai/gpt-4o-mini`) and a `get_weather` tool. Agent calls tool, formulates response, runner exits, spans flushed.
- [x] Full trace tree in Future AGI Observe:
  - `invocation [traceai_smoke]` (CHAIN, 7.8s) — `user.id`, `gen_ai.conversation.id`, input/output captured.
  - `agent_run [weather_agent]` (AGENT, 7.8s).
  - `invoke_agent weather_agent` (google-adk's own internal span, 7.8s).
  - `generate_content openai/gpt-4o-mini` (LLM, 4.8s, #119 tokens) — first LLM call.
    - `execute_tool get_weather` (TOOL) — proves the `tracing.trace_tool_call` patch fires.
  - `generate_content openai/gpt-4o-mini` (LLM, 2.3s, #162 tokens) — second LLM call.
- [x] Final agent response: `\"The weather in San Francisco is 21°C and partly cloudy.\"` — tool call completed successfully through the instrumented path.

## Files changed

- `python/frameworks/google-adk/traceai_google_adk/__init__.py` — 134 insertions, 69 deletions.