### PR TITLE
fix(a2a): a2a-sdk 1.x compat + input/output capture

### DIFF
--- a/python/frameworks/a2a/traceai_a2a/__init__.py
+++ b/python/frameworks/a2a/traceai_a2a/__init__.py
@@ -14,7 +14,7 @@ For server-side (receiving agent):
 """
 
 import logging
-from typing import Any, Collection, Optional
+from typing import Any, Collection, List, Optional, Tuple
 
 import wrapt
 from opentelemetry import trace as trace_api
@@ -34,9 +34,19 @@ __all__ = [
     "__version__",
 ]
 
-# These are the methods we patch on A2AClient
+# a2a-sdk 0.x client: `A2AClient.send_task` / `A2AClient.send_task_streaming`.
 _SEND_TASK_METHOD = "send_task"
 _SEND_TASK_STREAMING_METHOD = "send_task_streaming"
+
+# a2a-sdk 1.x client: `Client.send_message` (always async, always streaming —
+# returns AsyncIterator[StreamResponse]). The streaming/non-streaming
+# distinction collapsed into a single method.
+_SEND_MESSAGE_METHOD = "send_message"
+
+# Tag attached to the resolved target tuple so the wrapper knows whether to
+# extract payload as a dict (v0) or a protobuf SendMessageRequest (v1).
+_API_V0 = "v0"
+_API_V1 = "v1"
 
 
 class A2AInstrumentor(BaseInstrumentor):
@@ -77,8 +87,11 @@ class A2AInstrumentor(BaseInstrumentor):
             schema_url="https://opentelemetry.io/schemas/1.11.0",
         )
 
-        # Allow tests to pass a pre-resolved client_class directly
+        # Allow tests to pass a pre-resolved client_class directly. When a
+        # tester supplies one we default to the v0 method set; if they need
+        # v1 they can pass `_api_version` too.
         client_class = kwargs.get("_client_class")
+        api_version: Optional[str] = kwargs.get("_api_version")
 
         if client_class is None:
             a2a_module = self._get_a2a_module()
@@ -90,39 +103,38 @@ class A2AInstrumentor(BaseInstrumentor):
                 )
                 return
 
-            client_class = self._get_client_class(a2a_module)
-            if client_class is None:
+            resolved = self._resolve_client_class(a2a_module)
+            if resolved is None:
                 logger.warning(
-                    "traceai-a2a: Could not locate A2AClient class in a2a module. "
-                    "The SDK structure may have changed. Please file an issue."
+                    "traceai-a2a: Could not locate an A2A client class in the "
+                    "installed a2a-sdk. The SDK structure may have changed. "
+                    "Please file an issue."
                 )
                 return
+            client_class, api_version = resolved
+        elif api_version is None:
+            api_version = _API_V0
 
-        wrapper = A2AClientWrapper(tracer=tracer)
+        wrapper = A2AClientWrapper(tracer=tracer, api_version=api_version)
 
-        # Patch send_task (sync/async) — marks it as non-streaming
-        if hasattr(client_class, _SEND_TASK_METHOD):
-            original_send_task = getattr(client_class, _SEND_TASK_METHOD)
-            original_send_task._a2a_streaming = False
-            wrapt.wrap_function_wrapper(
-                client_class,
-                _SEND_TASK_METHOD,
-                wrapper,
+        for method_name, is_streaming in self._methods_for_api(api_version):
+            if not hasattr(client_class, method_name):
+                continue
+            original = getattr(client_class, method_name)
+            # Marker the wrapper reads to pick streaming vs non-streaming
+            # handling. Safe to attach to a function object; for the v1 entry
+            # point it's always True so the marker is redundant but kept
+            # uniform with the v0 path.
+            try:
+                original._a2a_streaming = is_streaming
+            except (AttributeError, TypeError):
+                pass
+            wrapt.wrap_function_wrapper(client_class, method_name, wrapper)
+            logger.debug(
+                "traceai-a2a: Patched %s.%s",
+                client_class.__name__,
+                method_name,
             )
-            logger.debug("traceai-a2a: Patched A2AClient.send_task")
-
-        # Patch send_task_streaming (sync/async) — marks it as streaming
-        if hasattr(client_class, _SEND_TASK_STREAMING_METHOD):
-            original_send_task_streaming = getattr(
-                client_class, _SEND_TASK_STREAMING_METHOD
-            )
-            original_send_task_streaming._a2a_streaming = True
-            wrapt.wrap_function_wrapper(
-                client_class,
-                _SEND_TASK_STREAMING_METHOD,
-                wrapper,
-            )
-            logger.debug("traceai-a2a: Patched A2AClient.send_task_streaming")
 
         logger.info(
             "traceai-a2a v%s: A2AInstrumentor active — "
@@ -135,19 +147,35 @@ class A2AInstrumentor(BaseInstrumentor):
         if a2a_module is None:
             return
 
-        client_class = self._get_client_class(a2a_module)
-        if client_class is None:
+        resolved = self._resolve_client_class(a2a_module)
+        if resolved is None:
             return
+        client_class, api_version = resolved
 
-        for method_name in (_SEND_TASK_METHOD, _SEND_TASK_STREAMING_METHOD):
+        for method_name, _ in self._methods_for_api(api_version):
             patched = getattr(client_class, method_name, None)
             if patched and hasattr(patched, "__wrapped__"):
                 setattr(client_class, method_name, patched.__wrapped__)
-                logger.debug("traceai-a2a: Unpatched A2AClient.%s", method_name)
+                logger.debug(
+                    "traceai-a2a: Unpatched %s.%s",
+                    client_class.__name__,
+                    method_name,
+                )
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _methods_for_api(api_version: str) -> List[Tuple[str, bool]]:
+        """Return the (method_name, is_streaming) pairs to patch per API."""
+        if api_version == _API_V1:
+            # `Client.send_message` always returns an AsyncIterator.
+            return [(_SEND_MESSAGE_METHOD, True)]
+        return [
+            (_SEND_TASK_METHOD, False),
+            (_SEND_TASK_STREAMING_METHOD, True),
+        ]
 
     def _get_a2a_module(self) -> Optional[Any]:
         """
@@ -160,21 +188,38 @@ class A2AInstrumentor(BaseInstrumentor):
         except ImportError:
             return None
 
-    def _get_client_class(self, a2a_module: Any) -> Optional[type]:
+    def _resolve_client_class(
+        self, a2a_module: Any
+    ) -> Optional[Tuple[type, str]]:
         """
-        Locate the A2AClient class in the a2a module.
-        Tries common locations used across SDK versions.
+        Locate the A2A client class and report which API generation it is.
+
+        Returns (class, api_version) where api_version is "v0" for the old
+        ``A2AClient.send_task`` shape and "v1" for the post-rename
+        ``Client.send_message`` shape. The v1 lookup is tried first because
+        installs of a2a-sdk >= 1.0 re-export the new ``Client`` class while
+        no longer providing ``A2AClient``.
         """
-        # a2a-sdk >= 0.2.x: a2a.client.A2AClient
+        # a2a-sdk >= 1.0: a2a.client.Client (send_message / async streaming)
         try:
-            from a2a.client import A2AClient
-            return A2AClient
+            from a2a.client import Client as _Client  # type: ignore[attr-defined]
+
+            if isinstance(_Client, type):
+                return _Client, _API_V1
         except ImportError:
             pass
 
-        # Fallback: a2a.A2AClient (flat namespace in older versions)
+        # a2a-sdk >= 0.2: a2a.client.A2AClient
+        try:
+            from a2a.client import A2AClient  # type: ignore[attr-defined]
+
+            return A2AClient, _API_V0
+        except ImportError:
+            pass
+
+        # Older flat-namespace fallback
         client_class = getattr(a2a_module, "A2AClient", None)
-        if client_class is not None and isinstance(client_class, type):
-            return client_class
+        if isinstance(client_class, type):
+            return client_class, _API_V0
 
         return None

--- a/python/frameworks/a2a/traceai_a2a/_a2a_client.py
+++ b/python/frameworks/a2a/traceai_a2a/_a2a_client.py
@@ -24,6 +24,7 @@ last-resort finalizer in case the caller drops the reference without
 iterating.
 """
 
+import inspect
 import logging
 from contextlib import contextmanager
 from typing import Any, AsyncIterator, Dict, Iterator, Mapping, Optional, Tuple
@@ -36,8 +37,10 @@ from opentelemetry.trace import INVALID_SPAN, Span, Status, StatusCode, Tracer
 from opentelemetry.util.types import AttributeValue
 
 from traceai_a2a._attributes import (
+    extract_artifact_text,
     get_agent_card_attributes,
     get_artifact_type,
+    get_send_message_request_attributes,
     get_send_task_payload_attributes,
     get_task_attributes,
 )
@@ -52,12 +55,20 @@ from traceai_a2a._semantic_conventions import (
     TASK_STATE_FAILED,
 )
 
+# API generation tags shared with __init__.py; duplicated here to avoid a
+# circular import.
+_API_V0 = "v0"
+_API_V1 = "v1"
+
 try:
     from fi_instrumentation import get_attributes_from_context
     from fi_instrumentation.fi_types import SpanAttributes
+
     _FI_AVAILABLE = True
+    _OUTPUT_VALUE_KEY = SpanAttributes.OUTPUT_VALUE
 except ImportError:
     _FI_AVAILABLE = False
+    _OUTPUT_VALUE_KEY = "output.value"
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +165,7 @@ class _StreamingSpanWrapper:
         self._span = span
         self._last_artifact_type: Optional[str] = None
         self._last_task_state: Optional[str] = None
+        self._output_fragments: list = []
         self._span_ended = False
 
     # --- iterator protocol ---------------------------------------------------
@@ -175,12 +187,15 @@ class _StreamingSpanWrapper:
             self._finalize_span(error=True)
             raise
 
-        # Capture artifact type from streaming events
-        artifact = getattr(event, "artifact", None)
+        # Capture artifact type AND text content from streaming events
+        artifact = _extract_event_artifact(event)
         if artifact is not None:
             atype = get_artifact_type(artifact)
             if atype:
                 self._last_artifact_type = atype
+            text = extract_artifact_text(artifact)
+            if text:
+                self._output_fragments.append(text)
 
         # Capture task state from status events
         task_state = _extract_event_state(event)
@@ -211,6 +226,10 @@ class _StreamingSpanWrapper:
         self._span_ended = True
         if self._last_artifact_type:
             self._span.set_attribute(A2A_ARTIFACT_TYPE, self._last_artifact_type)
+        if self._output_fragments:
+            self._span.set_attribute(
+                _OUTPUT_VALUE_KEY, "".join(self._output_fragments)
+            )
         if self._last_task_state:
             self._span.set_attribute(A2A_TASK_STATE, self._last_task_state)
             if not error:
@@ -238,6 +257,7 @@ class _AsyncStreamingSpanWrapper:
         self._span = span
         self._last_artifact_type: Optional[str] = None
         self._last_task_state: Optional[str] = None
+        self._output_fragments: list = []
         self._span_ended = False
 
     # --- async iterator protocol --------------------------------------------
@@ -259,11 +279,14 @@ class _AsyncStreamingSpanWrapper:
             self._finalize_span(error=True)
             raise
 
-        artifact = getattr(event, "artifact", None)
+        artifact = _extract_event_artifact(event)
         if artifact is not None:
             atype = get_artifact_type(artifact)
             if atype:
                 self._last_artifact_type = atype
+            text = extract_artifact_text(artifact)
+            if text:
+                self._output_fragments.append(text)
 
         task_state = _extract_event_state(event)
         if task_state:
@@ -293,6 +316,10 @@ class _AsyncStreamingSpanWrapper:
         self._span_ended = True
         if self._last_artifact_type:
             self._span.set_attribute(A2A_ARTIFACT_TYPE, self._last_artifact_type)
+        if self._output_fragments:
+            self._span.set_attribute(
+                _OUTPUT_VALUE_KEY, "".join(self._output_fragments)
+            )
         if self._last_task_state:
             self._span.set_attribute(A2A_TASK_STATE, self._last_task_state)
             if not error:
@@ -310,13 +337,54 @@ class _AsyncStreamingSpanWrapper:
 # ---------------------------------------------------------------------------
 
 def _extract_event_state(event: Any) -> Optional[str]:
-    """Try to extract task state from a streaming event object."""
+    """Try to extract task state from a streaming event object.
+
+    Handles both the v0 SDK shape (event has a top-level ``.status``) and the
+    v1 protobuf ``StreamResponse`` shape (oneof of ``task`` /
+    ``status_update`` / ``artifact_update`` / ``message``). On v1 the status
+    lives at ``event.status_update.status`` for incremental updates and at
+    ``event.task.status`` when the full task is delivered.
+    """
     try:
-        status = getattr(event, "status", None)
-        if status:
+        for status_owner in (
+            getattr(event, "status_update", None),
+            getattr(event, "task", None),
+            event,
+        ):
+            if status_owner is None:
+                continue
+            status = getattr(status_owner, "status", None)
+            if not status:
+                continue
             state = getattr(status, "state", None)
-            if state:
-                return str(state.value if hasattr(state, "value") else state)
+            if state in (None, 0, ""):  # protobuf default = TASK_STATE_UNSPECIFIED
+                continue
+            return str(state.value if hasattr(state, "value") else state)
+    except Exception:
+        pass
+    return None
+
+
+def _extract_event_artifact(event: Any) -> Any:
+    """Pull an artifact off a streaming event in v0 or v1 shape.
+
+    v0: ``event.artifact``. v1: ``event.artifact_update.artifact`` (and
+    ``event.task.artifacts`` carries them in batch on the final task event).
+    """
+    try:
+        direct = getattr(event, "artifact", None)
+        if direct is not None:
+            return direct
+        artifact_update = getattr(event, "artifact_update", None)
+        if artifact_update is not None:
+            artifact = getattr(artifact_update, "artifact", None)
+            if artifact is not None:
+                return artifact
+        task = getattr(event, "task", None)
+        if task is not None:
+            artifacts = getattr(task, "artifacts", None) or []
+            if len(artifacts) > 0:
+                return artifacts[-1]
     except Exception:
         pass
     return None
@@ -328,17 +396,30 @@ def _extract_event_state(event: Any) -> Optional[str]:
 
 class A2AClientWrapper:
     """
-    Wraps the A2A Python SDK's A2AClient to add OpenTelemetry instrumentation.
+    Wraps the A2A Python SDK's client class to add OpenTelemetry instrumentation.
 
-    This is installed via wrapt into A2AClient.send_task and
-    A2AClient.send_task_streaming by A2AInstrumentor._instrument().
+    Two API generations are supported and dispatched based on ``api_version``:
+
+    * **v0** (a2a-sdk < 1.0): ``A2AClient.send_task`` (sync) and
+      ``A2AClient.send_task_streaming`` (sync iterator). Payload is a dict;
+      W3C trace context is injected into ``kwargs["headers"]`` so it reaches
+      the outbound HTTP request.
+
+    * **v1** (a2a-sdk >= 1.0): ``Client.send_message`` — an ``async def`` that
+      returns ``AsyncIterator[StreamResponse]`` (streaming is the only mode).
+      Payload is a protobuf ``SendMessageRequest`` and the call signature has
+      no ``headers`` kwarg, so HTTP-header injection is skipped on v1; the
+      W3C trace-id is still recorded on the local span as
+      ``gen_ai.a2a.propagated_trace_id``. Future work: plumb context into
+      the SDK's ``ClientCallInterceptor`` so it crosses the wire too.
     """
 
-    def __init__(self, tracer: Tracer) -> None:
+    def __init__(self, tracer: Tracer, api_version: str = _API_V0) -> None:
         self._tracer = tracer
+        self._api_version = api_version
 
     # ------------------------------------------------------------------
-    # Sync wrapper for send_task
+    # wrapt entry point. Routes sync vs async based on the wrapped function.
     # ------------------------------------------------------------------
 
     def __call__(
@@ -351,35 +432,45 @@ class A2AClientWrapper:
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
 
-        agent_url = self._get_agent_url(instance)
-        payload = self._extract_payload(args, kwargs)
-        is_streaming = getattr(wrapped, "_a2a_streaming", False)
+        if inspect.iscoroutinefunction(wrapped):
+            return self._async_call(wrapped, instance, args, kwargs)
+        return self._sync_call(wrapped, instance, args, kwargs)
 
-        payload_attrs = dict(get_send_task_payload_attributes(payload, streaming=is_streaming))
+    # ------------------------------------------------------------------
+    # Sync code path — v0 only (`A2AClient.send_task` / `send_task_streaming`).
+    # ------------------------------------------------------------------
+
+    def _sync_call(
+        self,
+        wrapped: Any,
+        instance: Any,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        is_streaming = getattr(wrapped, "_a2a_streaming", False)
+        span_name = self._span_name(is_streaming)
+        agent_url = self._get_agent_url(instance)
+        payload_attrs = self._payload_attributes(args, kwargs, is_streaming)
 
         with _start_a2a_client_span(
             tracer=self._tracer,
             agent_url=agent_url,
-            span_name="A2AClient.send_task_streaming" if is_streaming else "A2AClient.send_task",
+            span_name=span_name,
             extra_attributes=payload_attrs,
         ) as span:
-            # Inject distributed trace context into outbound headers
             propagated_headers, trace_id = _inject_trace_context()
             if trace_id:
                 span.set_attribute(A2A_PROPAGATED_TRACE_ID, trace_id)
 
-            # Merge propagation headers into the call kwargs
-            kwargs = self._inject_headers(kwargs, propagated_headers)
+            if self._api_version == _API_V0:
+                kwargs = self._inject_headers(kwargs, propagated_headers)
 
             try:
                 result = wrapped(*args, **kwargs)
 
                 if is_streaming:
-                    # Return a wrapper object — span.end() is guaranteed via
-                    # close() or __del__, even if caller breaks early.
                     return _StreamingSpanWrapper(result, span)
 
-                # Non-streaming: extract task attributes from the returned Task
                 self._finalize_span_from_task(span, result)
                 span.set_status(Status(StatusCode.OK))
                 return result
@@ -395,48 +486,39 @@ class A2AClientWrapper:
                     span.end()
 
     # ------------------------------------------------------------------
-    # Async wrapper for send_task (async version)
+    # Async code path — primarily v1 (`Client.send_message`) but also covers
+    # any v0 install that happens to expose an async send_task.
     # ------------------------------------------------------------------
 
-    async def __call_async__(
+    async def _async_call(
         self,
         wrapped: Any,
         instance: Any,
         args: Tuple[Any, ...],
         kwargs: Mapping[str, Any],
     ) -> Any:
-        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
-            return await wrapped(*args, **kwargs)
-
-        agent_url = self._get_agent_url(instance)
-        payload = self._extract_payload(args, kwargs)
         is_streaming = getattr(wrapped, "_a2a_streaming", False)
-
-        payload_attrs = dict(get_send_task_payload_attributes(payload, streaming=is_streaming))
+        span_name = self._span_name(is_streaming)
+        agent_url = self._get_agent_url(instance)
+        payload_attrs = self._payload_attributes(args, kwargs, is_streaming)
 
         with _start_a2a_client_span(
             tracer=self._tracer,
             agent_url=agent_url,
-            span_name="A2AClient.send_task_streaming" if is_streaming else "A2AClient.send_task",
+            span_name=span_name,
             extra_attributes=payload_attrs,
         ) as span:
             propagated_headers, trace_id = _inject_trace_context()
             if trace_id:
                 span.set_attribute(A2A_PROPAGATED_TRACE_ID, trace_id)
 
-            kwargs = self._inject_headers(kwargs, propagated_headers)
+            if self._api_version == _API_V0:
+                kwargs = self._inject_headers(kwargs, propagated_headers)
 
             try:
-                import asyncio
-                if asyncio.iscoroutinefunction(wrapped):
-                    result = await wrapped(*args, **kwargs)
-                else:
-                    # async generator — call without await, returns async_generator object
-                    result = wrapped(*args, **kwargs)
+                result = await wrapped(*args, **kwargs)
 
                 if is_streaming:
-                    # Return a wrapper object — span.end() is guaranteed via
-                    # aclose() or __del__, even if caller breaks early.
                     return _AsyncStreamingSpanWrapper(result, span)
 
                 self._finalize_span_from_task(span, result)
@@ -457,8 +539,42 @@ class A2AClientWrapper:
     # Helpers
     # ------------------------------------------------------------------
 
+    def _span_name(self, is_streaming: bool) -> str:
+        if self._api_version == _API_V1:
+            return "Client.send_message"
+        return (
+            "A2AClient.send_task_streaming" if is_streaming else "A2AClient.send_task"
+        )
+
+    def _payload_attributes(
+        self,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+        is_streaming: bool,
+    ) -> Dict[str, AttributeValue]:
+        """Build pre-call payload attributes for the span.
+
+        Dispatches on api_version so v1 (protobuf SendMessageRequest) and
+        v0 (dict payload) each use their own extractor.
+        """
+        if self._api_version == _API_V1:
+            request = self._first_positional_or_kwarg(args, kwargs, "request")
+            return dict(
+                get_send_message_request_attributes(request, streaming=is_streaming)
+            )
+
+        payload = self._extract_v0_payload(args, kwargs)
+        return dict(
+            get_send_task_payload_attributes(payload, streaming=is_streaming)
+        )
+
     def _get_agent_url(self, instance: Any) -> str:
-        """Extract the agent base URL from the A2AClient instance."""
+        """Extract the agent base URL from the client instance.
+
+        Probes several common attribute names because the field name has
+        shifted across SDK versions (``url`` → ``base_url`` → ``_url`` → in
+        v1 the URL lives behind the transport, accessible via ``url`` again).
+        """
         try:
             url = (
                 getattr(instance, "url", None)
@@ -470,12 +586,12 @@ class A2AClientWrapper:
         except Exception:
             return "unknown"
 
-    def _extract_payload(
-        self, args: Tuple[Any, ...], kwargs: Mapping[str, Any]
+    @staticmethod
+    def _extract_v0_payload(
+        args: Tuple[Any, ...], kwargs: Mapping[str, Any]
     ) -> Dict[str, Any]:
-        """Extract the task payload dict from call arguments."""
+        """Extract a v0 dict payload from call arguments."""
         try:
-            # A2AClient.send_task(payload={...}) or send_task({...})
             if kwargs.get("payload"):
                 return dict(kwargs["payload"])
             if args and isinstance(args[0], dict):
@@ -484,14 +600,26 @@ class A2AClientWrapper:
             logger.debug("Failed to extract A2A payload", exc_info=True)
         return {}
 
+    @staticmethod
+    def _first_positional_or_kwarg(
+        args: Tuple[Any, ...], kwargs: Mapping[str, Any], name: str
+    ) -> Any:
+        if name in kwargs:
+            return kwargs[name]
+        if args:
+            return args[0]
+        return None
+
     def _inject_headers(
         self, kwargs: Mapping[str, Any], extra_headers: Dict[str, str]
     ) -> Dict[str, Any]:
         """
         Merge W3C propagation headers into the kwargs passed to A2AClient.
 
-        A2AClient accepts headers via kwargs["headers"] (passed through to httpx).
-        We merge without overwriting any existing headers the caller may have set.
+        Only meaningful on v0 — v0's ``send_task`` accepts a ``headers``
+        kwarg that is passed through to httpx. v1's ``Client.send_message``
+        has no such kwarg, so the caller is responsible for routing this
+        path only for v0 (see ``_sync_call`` / ``_async_call`` above).
         """
         kwargs = dict(kwargs)
         existing = dict(kwargs.get("headers") or {})

--- a/python/frameworks/a2a/traceai_a2a/_attributes.py
+++ b/python/frameworks/a2a/traceai_a2a/_attributes.py
@@ -8,7 +8,7 @@ following the same pattern as other traceAI attribute extractors.
 
 import json
 import logging
-from typing import Any, Dict, Iterator, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from traceai_a2a._semantic_conventions import (
     A2A_AGENT_CARD_NAME,
@@ -23,9 +23,79 @@ from traceai_a2a._semantic_conventions import (
     A2A_TASK_STATE,
 )
 
+try:
+    # Optional — used to surface FI canonical input.value / output.value keys
+    # so the Future AGI dashboard's Input/Output panels populate.
+    from fi_instrumentation.fi_types import SpanAttributes as _FISpanAttributes
+
+    _INPUT_VALUE_KEY = _FISpanAttributes.INPUT_VALUE
+    _OUTPUT_VALUE_KEY = _FISpanAttributes.OUTPUT_VALUE
+except Exception:  # pragma: no cover - fallback to raw OI keys
+    _INPUT_VALUE_KEY = "input.value"
+    _OUTPUT_VALUE_KEY = "output.value"
+
 logger = logging.getLogger(__name__)
 
 AttributeYield = Iterator[Tuple[str, Any]]
+
+
+def _part_text(part: Any) -> Optional[str]:
+    """Pull text out of a Part across v0 (`.text` / dict) and v1 (protobuf)."""
+    try:
+        # v0 / v1 both expose `.text` directly for text parts.
+        text = getattr(part, "text", None)
+        if isinstance(text, str) and text:
+            return text
+        if isinstance(part, dict):
+            text = part.get("text")
+            if isinstance(text, str) and text:
+                return text
+    except Exception:
+        pass
+    return None
+
+
+def extract_parts_text(parts: Any) -> str:
+    """Join the text content of a sequence of Parts into one string."""
+    if not parts:
+        return ""
+    fragments: List[str] = []
+    try:
+        for part in parts:
+            text = _part_text(part)
+            if text:
+                fragments.append(text)
+    except Exception:
+        logger.debug("Failed to extract text from parts", exc_info=True)
+    return "".join(fragments)
+
+
+def extract_message_text(message: Any) -> str:
+    """Join the text content of a Message's parts."""
+    if message is None:
+        return ""
+    try:
+        parts = getattr(message, "parts", None)
+        if parts is None and isinstance(message, dict):
+            parts = message.get("parts")
+        return extract_parts_text(parts)
+    except Exception:
+        logger.debug("Failed to extract message text", exc_info=True)
+        return ""
+
+
+def extract_artifact_text(artifact: Any) -> str:
+    """Join the text content of an Artifact's parts."""
+    if artifact is None:
+        return ""
+    try:
+        parts = getattr(artifact, "parts", None)
+        if parts is None and isinstance(artifact, dict):
+            parts = artifact.get("parts")
+        return extract_parts_text(parts)
+    except Exception:
+        logger.debug("Failed to extract artifact text", exc_info=True)
+        return ""
 
 
 def get_task_attributes(task: Any) -> AttributeYield:
@@ -57,6 +127,19 @@ def get_task_attributes(task: Any) -> AttributeYield:
                 yield A2A_TASK_STATE, str(state)
     except Exception:
         logger.debug("Failed to extract task state", exc_info=True)
+
+    try:
+        # Surface the final artifact text as output.value so the dashboard's
+        # Output panel populates on non-streaming v0 calls.
+        artifacts = getattr(task, "artifacts", None)
+        if artifacts is None and isinstance(task, dict):
+            artifacts = task.get("artifacts")
+        if artifacts:
+            output_text = "".join(extract_artifact_text(a) for a in artifacts)
+            if output_text:
+                yield _OUTPUT_VALUE_KEY, output_text
+    except Exception:
+        logger.debug("Failed to extract task output text", exc_info=True)
 
 
 def get_message_attributes(message: Any) -> AttributeYield:
@@ -109,6 +192,12 @@ def get_artifact_type(artifact: Any) -> Optional[str]:
     """
     Determine the type of an A2A artifact.
     Returns one of: 'text', 'file', 'data', or None.
+
+    In a2a-sdk 0.x ``Part`` carried a ``type`` discriminator. In 1.x the
+    type information is encoded by which field on the protobuf ``Part`` is
+    populated — ``text``, ``raw``, ``url``, ``data``, ``filename``,
+    ``media_type``. We probe the v0 discriminator first; if absent we
+    infer the type from the populated v1 field.
     """
     try:
         parts = getattr(artifact, "parts", None) or (
@@ -117,13 +206,26 @@ def get_artifact_type(artifact: Any) -> Optional[str]:
         if not parts:
             return None
         first_part = parts[0]
+        # v0 discriminator
         part_type = getattr(first_part, "type", None) or (
             first_part.get("type") if isinstance(first_part, dict) else None
         )
-        return _enum_or_str(part_type) if part_type else None
+        if part_type:
+            return _enum_or_str(part_type)
+        # v1 protobuf Part — infer from populated oneof-ish field.
+        for field_name, label in (
+            ("text", "text"),
+            ("raw", "file"),
+            ("url", "file"),
+            ("filename", "file"),
+            ("data", "data"),
+        ):
+            value = getattr(first_part, field_name, None)
+            if value:
+                return label
     except Exception:
         logger.debug("Failed to determine artifact type", exc_info=True)
-        return None
+    return None
 
 
 def get_send_task_payload_attributes(payload: Dict[str, Any], streaming: bool) -> AttributeYield:
@@ -146,6 +248,11 @@ def get_send_task_payload_attributes(payload: Dict[str, Any], streaming: bool) -
         message = payload.get("message", {})
         if message:
             yield from get_message_attributes(message)
+            # Surface the user-message text as input.value so the Future AGI
+            # dashboard's Input panel shows the prompt instead of being blank.
+            input_text = extract_message_text(message)
+            if input_text:
+                yield _INPUT_VALUE_KEY, input_text
     except Exception:
         logger.debug("Failed to extract message attributes from payload", exc_info=True)
 
@@ -157,6 +264,38 @@ def get_send_task_payload_attributes(payload: Dict[str, Any], streaming: bool) -
                 yield A2A_PUSH_NOTIFICATION_URL, str(url)
     except Exception:
         logger.debug("Failed to extract push notification URL", exc_info=True)
+
+
+def get_send_message_request_attributes(
+    request: Any, streaming: bool
+) -> AttributeYield:
+    """Extract attributes from an a2a-sdk 1.x ``SendMessageRequest`` protobuf.
+
+    ``Client.send_message(request: SendMessageRequest, *, context=None)``.
+    The request carries a single ``Message`` whose ``task_id`` / ``role`` /
+    ``parts`` we surface. Falls back gracefully if the request is missing
+    or doesn't look like a SendMessageRequest.
+    """
+    yield A2A_STREAMING, streaming
+
+    if request is None:
+        return
+
+    try:
+        message = getattr(request, "message", None)
+        if message is None:
+            return
+        task_id = getattr(message, "task_id", None)
+        if task_id:
+            yield A2A_TASK_ID, str(task_id)
+        yield from get_message_attributes(message)
+        input_text = extract_message_text(message)
+        if input_text:
+            yield _INPUT_VALUE_KEY, input_text
+    except Exception:
+        logger.debug(
+            "Failed to extract attributes from SendMessageRequest", exc_info=True
+        )
 
 
 def _enum_or_str(value: Any) -> str:


### PR DESCRIPTION
## Summary

`A2AInstrumentor` silently no-op'd on `a2a-sdk` 1.x — `instrument()` returned cleanly with a single WARNING log, no methods were wrapped, every A2A call produced zero spans. The SDK restructured its client surface in 1.0: the class was renamed `A2AClient → Client`, the two send methods collapsed into a single async-streaming `Client.send_message`, and request/response types moved to protobuf. The wrapper's `_get_client_class` couldn't find `A2AClient` anywhere, hit its \"SDK structure may have changed\" warning path, and bailed.

This PR (a) makes the instrumentor work on both v0 and v1, and (b) fills the FI dashboard's Input/Output panels which were never populated even on v0. Verified end-to-end against `a2a-sdk` 1.0.2.

## What was broken on a2a-sdk 1.x

| Concern | a2a-sdk 0.x | a2a-sdk 1.x | Effect on the unfixed wrapper |
|---|---|---|---|
| Client class | `A2AClient` | `Client` | `_get_client_class` returns None → warning, no patching |
| Send methods | `send_task` + `send_task_streaming` | unified `send_message` (always async, always streaming) | Even if class found, neither attribute exists → silent skip |
| Request type | dict payload | protobuf `SendMessageRequest` | `_extract_payload`'s `dict.get(\"payload\")` finds nothing |
| Stream events | direct `event.artifact` / `event.status` | oneof of `task` / `message` / `status_update` / `artifact_update` | `_extract_event_state` / artifact access all return None |
| `Part.type` | discriminator string | gone — type encoded by populated field | `get_artifact_type` always returns None |
| Header injection | `kwargs[\"headers\"]` passes through to httpx | `Client.send_message` has no `headers` kwarg | Would TypeError if we forced it |
| Sync/async | sync | `async def` returning `AsyncIterator` | Existing sync `__call__` would return the coroutine without awaiting; the dead `__call_async__` was never reached by wrapt |

## What this patch changes

All three files in `traceai_a2a/`:

### `__init__.py`

- `_resolve_client_class` returns `(class, api_version)` and tries `a2a.client.Client` first, falls back to `a2a.client.A2AClient`, then to `getattr(a2a_module, \"A2AClient\", None)`.
- `_methods_for_api(api_version)` returns `[(\"send_message\", True)]` on v1 and `[(\"send_task\", False), (\"send_task_streaming\", True)]` on v0.
- `_instrument` / `_uninstrument` iterate that list instead of hard-coding the two v0 methods.
- The `_a2a_streaming` marker is still attached to each wrapped function for symmetry — always True on v1.

### `_a2a_client.py`

- `A2AClientWrapper.__init__` takes an `api_version` (default v0 for backward compat with tests that don't pass it).
- `__call__` dispatches to `_sync_call` or `_async_call` based on `inspect.iscoroutinefunction(wrapped)`. Removed the dead `__call_async__` method.
- `_async_call` awaits the wrapped coroutine, wraps the returned `AsyncIterator` with `_AsyncStreamingSpanWrapper`, handles the streaming-only v1 path.
- W3C header injection is skipped on v1 (no `headers` kwarg). The W3C trace-id is still recorded locally as `gen_ai.a2a.propagated_trace_id`.
- Span name is `Client.send_message` on v1, unchanged on v0.
- New `_extract_event_state` walks the v1 oneof (`event.status_update.status` → `event.task.status` → fallback to v0's `event.status`).
- New `_extract_event_artifact` walks the v1 oneof (`event.artifact_update.artifact` → `event.task.artifacts[-1]` → fallback to v0's `event.artifact`).
- Both streaming wrappers now accumulate text from each artifact into `_output_fragments`, joined and emitted as `output.value` in `_finalize_span`.

### `_attributes.py`

- New text helpers: `_part_text`, `extract_parts_text`, `extract_message_text`, `extract_artifact_text` (handle both v0 and v1 part shapes).
- New `get_send_message_request_attributes` extracts task_id / role / parts.count / **input text** from a protobuf `SendMessageRequest`.
- `get_send_task_payload_attributes` (v0) now also emits **input text** from `payload[\"message\"]` parts.
- `get_task_attributes` (v0 non-streaming) now also emits **output text** from `task.artifacts[*].parts`.
- `get_artifact_type` falls back to inferring `\"text\"` / `\"file\"` / `\"data\"` from the populated v1 `Part` field when the v0 `.type` discriminator is absent.

## What's NOT changed (out of scope)

- **Cross-wire W3C propagation on v1.** The trace-id is recorded locally, but the outbound request doesn't carry `traceparent` because there's no `headers` kwarg. The proper hook is `ClientCallInterceptor` — separate PR.
- **Server-side `_a2a_server.py`.** Not audited or changed. If the inbound A2A server shape also moved in 1.x, it's a separate fix.
- **Protobuf enum readability.** `gen_ai.a2a.task.state = 3` and `gen_ai.a2a.message.role = 1` surface as integers; readable names would need a `pb.TaskState.Name(value)` translation in `_enum_or_str`. Cosmetic.
- **pyproject** — no version pin tightening. The `[tool.poetry.extras] a2a = [\"a2a-sdk\"]` is unpinned and the package now works on both lines, so left alone.

## Test plan

- [x] `python -m py_compile` on all three changed files — syntax clean.
- [x] Fresh Python 3.12 venv with `a2a-sdk` 1.0.2, `fi-instrumentation-otel`, and the local `traceai-a2a` installed editable.
- [x] **Before fix:** `A2AInstrumentor().instrument()` logs `WARNING traceai_a2a: Could not locate A2AClient class in a2a module`; `Client.send_message.__wrapped__` is False; zero spans on any call.
- [x] **After fix:** `instrument()` runs cleanly; `Client.send_message.__wrapped__` is True; `_a2a_streaming = True`.
- [x] Smoke test: `FakeClient(Client)` subclass returning a canned `AsyncIterator` of `StreamResponse` (status_update WORKING → artifact_update with a text Part → status_update COMPLETED). All three events consumed, span flushed.
- [x] Span in Future AGI Observe (`traceai-a2a-smoke` project) shows:
  - status OK
  - `gen_ai.span.kind = \"A2A_CLIENT\"`
  - `gen_ai.a2a.agent.url = \"http://weather-agent.local\"`
  - `gen_ai.a2a.streaming = true`
  - `gen_ai.a2a.task.id = \"task-smoke-1\"` (extracted from protobuf `SendMessageRequest.message.task_id`)
  - `gen_ai.a2a.message.role = 1` (`ROLE_USER`)
  - `gen_ai.a2a.message.parts.count = 1`
  - `gen_ai.a2a.task.state = 3` (`TASK_STATE_COMPLETED`)
  - `gen_ai.a2a.artifact.type = \"text\"` (inferred from populated `Part.text` field)
  - `gen_ai.a2a.propagated_trace_id` matches the trace's own W3C id
  - **Input panel** populated with the user prompt text (from `input.value`)
  - **Output panel** populated with the accumulated artifact text (from `output.value`)

## Files changed

- `python/frameworks/a2a/traceai_a2a/__init__.py` — 78 / 57 ins/del
- `python/frameworks/a2a/traceai_a2a/_a2a_client.py` — 196 / 34 ins/del
- `python/frameworks/a2a/traceai_a2a/_attributes.py` — 137 / 8 ins/del