### PR TITLE
fix(chromadb): tag query span as RETRIEVER + populate input/output for FI dashboard

### DIFF
--- a/python/frameworks/chromadb/traceai_chromadb/_wrappers.py
+++ b/python/frameworks/chromadb/traceai_chromadb/_wrappers.py
@@ -15,6 +15,25 @@ from traceai_chromadb._attributes import (
     safe_json_dumps,
 )
 
+# FI canonical span-kind / IO keys. Optional dependency — gracefully degrade
+# if fi-instrumentation isn't installed so the wrapper still loads.
+try:
+    from fi_instrumentation.fi_types import FiSpanKindValues, SpanAttributes
+
+    _FI_SPAN_KIND = SpanAttributes.FI_SPAN_KIND
+    _FI_INPUT_VALUE = SpanAttributes.INPUT_VALUE
+    _FI_INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
+    _FI_OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
+    _FI_OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
+    _FI_RETRIEVER = FiSpanKindValues.RETRIEVER.value
+except Exception:  # pragma: no cover
+    _FI_SPAN_KIND = "gen_ai.span.kind"
+    _FI_INPUT_VALUE = "input.value"
+    _FI_INPUT_MIME_TYPE = "input.mime_type"
+    _FI_OUTPUT_VALUE = "output.value"
+    _FI_OUTPUT_MIME_TYPE = "output.mime_type"
+    _FI_RETRIEVER = "RETRIEVER"
+
 logger = logging.getLogger(__name__)
 
 
@@ -150,6 +169,22 @@ class QueryWrapper(BaseWrapper):
             attributes["db.vector.query.type"] = "text"
             attributes["db.vector.query.text_count"] = len(query_texts)
 
+        # FI canonical retriever attributes — without these the Future AGI
+        # dashboard renders Type=unknown and leaves Input/Output panels blank.
+        attributes[_FI_SPAN_KIND] = _FI_RETRIEVER
+        if query_texts:
+            attributes[_FI_INPUT_VALUE] = (
+                query_texts[0]
+                if len(query_texts) == 1
+                else safe_json_dumps(query_texts)
+            )
+            attributes[_FI_INPUT_MIME_TYPE] = "text/plain"
+        elif query_embeddings:
+            attributes[_FI_INPUT_VALUE] = safe_json_dumps(
+                {"query_embeddings_count": len(query_embeddings), "n_results": n_results}
+            )
+            attributes[_FI_INPUT_MIME_TYPE] = "application/json"
+
         with self._tracer.start_as_current_span(
             span_name,
             kind=SpanKind.CLIENT,
@@ -172,6 +207,17 @@ class QueryWrapper(BaseWrapper):
                         first_query_distances = result["distances"][0] if result["distances"] else []
                         if first_query_distances:
                             span.set_attribute(Attrs.RESULTS_SCORES, safe_json_dumps(first_query_distances[:10]))
+
+                    # FI canonical output.value — prefer the document texts so
+                    # the dashboard's Output panel shows the retrieved content.
+                    documents = result.get("documents")
+                    if documents and documents[0]:
+                        span.set_attribute(
+                            _FI_OUTPUT_VALUE, safe_json_dumps(documents[0])
+                        )
+                        span.set_attribute(
+                            _FI_OUTPUT_MIME_TYPE, "application/json"
+                        )
 
                 span.set_status(Status(StatusCode.OK))
                 return result


### PR DESCRIPTION
## Summary

`ChromaDBInstrumentor` produces a span for every `Collection.query()` with rich technical attributes (collection name, top_k, result ids, distance scores), but the Future AGI dashboard renders it as **Type: unknown** with empty Input/Output panels because the wrapper never sets the FI canonical retriever keys. Users following the package's documented quickstart see a span that *looks* broken even though the integration works at the wire level.

This PR adds three FI canonical attributes on the `QueryWrapper` only. No other wrapper is touched — `add`/`upsert`/`get`/`delete`/etc. aren't retrievals and shouldn't be tagged RETRIEVER. All existing `db.vector.*` attributes are preserved (additive change).

## What changes

All in `traceai_chromadb/_wrappers.py`:

- Optional `fi_instrumentation.fi_types` import with a raw-string fallback so the wrapper still loads if fi-instrumentation isn't available at import time.
- In `QueryWrapper.__call__`:
  - `gen_ai.span.kind = \"RETRIEVER\"` set before the span starts.
  - `input.value` from `query_texts` (joined if multiple) or a JSON summary `{query_embeddings_count, n_results}` for vector queries. Plus matching `input.mime_type`.
  - After the wrapped call: `output.value` from the first query's `documents` list, with `output.mime_type = application/json`.

## Verified end-to-end

Real ChromaDB 1.x → real Future AGI ingest endpoint → confirmed in the dashboard via the Future AGI MCP. The `chroma query` span shows:

| Field | Value |
|---|---|
| Type | Retriever |
| Input | `\"Where is the Eiffel Tower?\"` |
| Output | `[\"The Eiffel Tower is in Paris.\", \"The Statue of Liberty is in New York.\"]` |
| Existing attrs | `top_k=2`, `results.count=2`, `results.ids=[\"a\",\"b\"]`, `results.scores=[0.28, 1.46]` — all preserved |

## Out of scope

- **Per-document `retrieval.documents.N.*` attrs.** That's Tier 3 (the per-doc score table in the dashboard); this PR is Tier 2 only.
- **Other ChromaDB methods.** `add`/`upsert`/`get`/`delete` aren't retrievals.
- **Other vector-DB instrumentors.** The same gap exists in `milvus`, `pinecone`, `qdrant`, `weaviate`, `lancedb`, `pgvector` — each will get its own focused PR with the same fix shape.

## Test plan

- [x] `python -m py_compile python/frameworks/chromadb/traceai_chromadb/_wrappers.py` — clean
- [x] In-process span attribute check: confirmed `gen_ai.span.kind`, `input.value`, `input.mime_type`, `output.value`, `output.mime_type` all set with expected values
- [x] Real end-to-end run against ChromaDB + Future AGI: trace lands, dashboard shows Type=Retriever with populated Input/Output panels