### PR TITLE
fix(milvus): tag search/query spans as RETRIEVER + populate input/output

### DIFF
--- a/python/frameworks/milvus/traceai_milvus/_wrappers.py
+++ b/python/frameworks/milvus/traceai_milvus/_wrappers.py
@@ -6,6 +6,25 @@ from typing import Any, Callable
 
 from opentelemetry.trace import SpanKind, Status, StatusCode, Tracer
 
+# FI canonical span-kind / IO keys. Optional dependency — gracefully degrade
+# if fi-instrumentation isn't installed.
+try:
+    from fi_instrumentation.fi_types import FiSpanKindValues, SpanAttributes
+
+    _FI_SPAN_KIND = SpanAttributes.FI_SPAN_KIND
+    _FI_INPUT_VALUE = SpanAttributes.INPUT_VALUE
+    _FI_INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
+    _FI_OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
+    _FI_OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
+    _FI_RETRIEVER = FiSpanKindValues.RETRIEVER.value
+except Exception:  # pragma: no cover
+    _FI_SPAN_KIND = "gen_ai.span.kind"
+    _FI_INPUT_VALUE = "input.value"
+    _FI_INPUT_MIME_TYPE = "input.mime_type"
+    _FI_OUTPUT_VALUE = "output.value"
+    _FI_OUTPUT_MIME_TYPE = "output.mime_type"
+    _FI_RETRIEVER = "RETRIEVER"
+
 logger = logging.getLogger(__name__)
 
 
@@ -14,6 +33,21 @@ def safe_json_dumps(obj: Any) -> str:
         return json.dumps(obj)
     except (TypeError, ValueError):
         return str(obj)
+
+
+def _summarize_milvus_search_input(kwargs: dict) -> str:
+    """Render a JSON summary of a milvus search request for input.value."""
+    data = kwargs.get("data")
+    summary = {
+        "limit": kwargs.get("limit", 10),
+        "filter": str(kwargs["filter"]) if "filter" in kwargs else None,
+        "anns_field": kwargs.get("anns_field"),
+    }
+    if isinstance(data, list):
+        summary["vector_count"] = len(data)
+        if data and isinstance(data[0], (list, tuple)):
+            summary["vector_dim"] = len(data[0])
+    return safe_json_dumps({k: v for k, v in summary.items() if v is not None})
 
 
 class BaseWrapper:
@@ -42,12 +76,19 @@ class SearchWrapper(BaseWrapper):
         if "output_fields" in kwargs:
             attributes["db.vector.query.output_fields"] = safe_json_dumps(kwargs["output_fields"])
 
+        # FI canonical retriever attributes — populate Type/Input/Output panels.
+        attributes[_FI_SPAN_KIND] = _FI_RETRIEVER
+        attributes[_FI_INPUT_VALUE] = _summarize_milvus_search_input(kwargs)
+        attributes[_FI_INPUT_MIME_TYPE] = "application/json"
+
         with self._tracer.start_as_current_span("milvus search", kind=SpanKind.CLIENT, attributes=attributes) as span:
             try:
                 result = wrapped(*args, **kwargs)
                 if result:
                     total_results = sum(len(r) for r in result) if isinstance(result, list) else 0
                     span.set_attribute("db.vector.results.count", total_results)
+                    span.set_attribute(_FI_OUTPUT_VALUE, safe_json_dumps(result))
+                    span.set_attribute(_FI_OUTPUT_MIME_TYPE, "application/json")
                 span.set_status(Status(StatusCode.OK))
                 return result
             except Exception as e:
@@ -64,14 +105,27 @@ class QueryWrapper(BaseWrapper):
         attributes = self._get_attributes("query", collection_name)
         attributes["db.vector.query.top_k"] = limit
 
-        if "filter" in kwargs:
-            attributes["db.vector.query.filter"] = str(kwargs["filter"])
+        filter_expr = kwargs.get("filter")
+        if filter_expr is not None:
+            attributes["db.vector.query.filter"] = str(filter_expr)
+
+        # FI canonical retriever attributes.
+        attributes[_FI_SPAN_KIND] = _FI_RETRIEVER
+        attributes[_FI_INPUT_VALUE] = safe_json_dumps(
+            {
+                "filter": str(filter_expr) if filter_expr is not None else None,
+                "limit": limit,
+            }
+        )
+        attributes[_FI_INPUT_MIME_TYPE] = "application/json"
 
         with self._tracer.start_as_current_span("milvus query", kind=SpanKind.CLIENT, attributes=attributes) as span:
             try:
                 result = wrapped(*args, **kwargs)
                 if result:
                     span.set_attribute("db.vector.results.count", len(result))
+                    span.set_attribute(_FI_OUTPUT_VALUE, safe_json_dumps(result))
+                    span.set_attribute(_FI_OUTPUT_MIME_TYPE, "application/json")
                 span.set_status(Status(StatusCode.OK))
                 return result
             except Exception as e:


### PR DESCRIPTION
## Summary

`MilvusInstrumentor` emits spans for `search()` and `query()` with technical attributes (collection name, top_k, filter expression, result count), but never sets the FI canonical retriever attributes. The Future AGI dashboard renders both as **Type: unknown** with empty Input/Output panels even though the call itself succeeded.

This PR adds three FI canonical attributes on `SearchWrapper` and `QueryWrapper`. No other wrapper is touched.

## What changes

All in `traceai_milvus/_wrappers.py`:

- Optional `fi_instrumentation.fi_types` import with raw-string fallback.
- New `_summarize_milvus_search_input(kwargs)` helper — returns a JSON string with `vector_count`, `vector_dim`, `filter`, `anns_field`, `limit`. (The raw query vector is too large to put on a span attribute; a structural summary is more useful for the dashboard.)
- `SearchWrapper.__call__` sets `gen_ai.span.kind=\"RETRIEVER\"`, `input.value` (summary JSON), `input.mime_type`, and after the call `output.value` + `output.mime_type` from a JSON dump of the search result.
- `QueryWrapper.__call__` sets the same kind, `input.value` from `{filter, limit}` JSON, and `output.value` from the result rows.

`Insert` / `Upsert` / `Delete` / `Get` / `CreateCollection` / `DropCollection` are untouched — they aren't retrievals. All pre-existing `db.vector.*` attrs are preserved.

## Verified

- In-process attribute check via wrapt direct invocation: both wrappers produce the expected canonical keys.
- Real end-to-end ingest to Future AGI (mock callables stand in for live Milvus). Confirmed via Future AGI MCP that both `milvus search` and `milvus query` spans show:
  - Type: Retriever
  - Input panel: populated with JSON summary
  - Output panel: populated with JSON of mock result

## Out of scope

- Per-document `retrieval.documents.N.*` attrs (Tier 3, dashboard's per-doc table).
- The other 6 vector-DB instrumentors get the same fix shape in their own focused PRs.