### PR TITLE
fix(weaviate): tag near_*/hybrid/bm25 spans as RETRIEVER + populate input/output

### DIFF
--- a/python/frameworks/weaviate/traceai_weaviate/_wrappers.py
+++ b/python/frameworks/weaviate/traceai_weaviate/_wrappers.py
@@ -2,9 +2,27 @@
 
 import json
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from opentelemetry.trace import SpanKind, Status, StatusCode, Tracer
+
+# FI canonical span-kind / IO keys. Optional dependency.
+try:
+    from fi_instrumentation.fi_types import FiSpanKindValues, SpanAttributes
+
+    _FI_SPAN_KIND = SpanAttributes.FI_SPAN_KIND
+    _FI_INPUT_VALUE = SpanAttributes.INPUT_VALUE
+    _FI_INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
+    _FI_OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
+    _FI_OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
+    _FI_RETRIEVER = FiSpanKindValues.RETRIEVER.value
+except Exception:  # pragma: no cover
+    _FI_SPAN_KIND = "gen_ai.span.kind"
+    _FI_INPUT_VALUE = "input.value"
+    _FI_INPUT_MIME_TYPE = "input.mime_type"
+    _FI_OUTPUT_VALUE = "output.value"
+    _FI_OUTPUT_MIME_TYPE = "output.mime_type"
+    _FI_RETRIEVER = "RETRIEVER"
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +32,28 @@ def safe_json_dumps(obj: Any) -> str:
         return json.dumps(obj)
     except (TypeError, ValueError):
         return str(obj)
+
+
+def _weaviate_objects_summary(objects: Any) -> Optional[str]:
+    """Render an (uuid, properties) summary of weaviate result objects."""
+    try:
+        out = []
+        for obj in objects[:50]:
+            entry: dict = {}
+            uuid = getattr(obj, "uuid", None)
+            if uuid is not None:
+                entry["uuid"] = str(uuid)
+            props = getattr(obj, "properties", None)
+            if props is not None:
+                entry["properties"] = props
+            metadata = getattr(obj, "metadata", None)
+            if metadata is not None and hasattr(metadata, "score"):
+                entry["score"] = getattr(metadata, "score", None)
+            if entry:
+                out.append(entry)
+        return safe_json_dumps(out) if out else None
+    except Exception:
+        return None
 
 
 class BaseWrapper:
@@ -56,11 +96,30 @@ class NearVectorWrapper(BaseWrapper):
         if distance:
             attributes["db.vector.query.distance"] = distance
 
+        # FI canonical retriever attributes.
+        attributes[_FI_SPAN_KIND] = _FI_RETRIEVER
+        near_vector = kwargs.get("near_vector", args[0] if args else None)
+        input_summary = {
+            "limit": limit,
+            "certainty": certainty,
+            "distance": distance,
+        }
+        if isinstance(near_vector, list):
+            input_summary["vector_dim"] = len(near_vector)
+        attributes[_FI_INPUT_VALUE] = safe_json_dumps(
+            {k: v for k, v in input_summary.items() if v is not None}
+        )
+        attributes[_FI_INPUT_MIME_TYPE] = "application/json"
+
         with self._tracer.start_as_current_span("weaviate near_vector", kind=SpanKind.CLIENT, attributes=attributes) as span:
             try:
                 result = wrapped(*args, **kwargs)
                 if result and hasattr(result, "objects"):
                     span.set_attribute("db.vector.results.count", len(result.objects))
+                    summary = _weaviate_objects_summary(result.objects)
+                    if summary:
+                        span.set_attribute(_FI_OUTPUT_VALUE, summary)
+                        span.set_attribute(_FI_OUTPUT_MIME_TYPE, "application/json")
                 span.set_status(Status(StatusCode.OK))
                 return result
             except Exception as e:
@@ -78,11 +137,25 @@ class NearTextWrapper(BaseWrapper):
         attributes = self._get_attributes("query", collection_name, "near_text")
         attributes["db.vector.query.top_k"] = limit
 
+        # FI canonical retriever attributes.
+        attributes[_FI_SPAN_KIND] = _FI_RETRIEVER
+        if query:
+            attributes[_FI_INPUT_VALUE] = (
+                query if isinstance(query, str) else safe_json_dumps(query)
+            )
+            attributes[_FI_INPUT_MIME_TYPE] = (
+                "text/plain" if isinstance(query, str) else "application/json"
+            )
+
         with self._tracer.start_as_current_span("weaviate near_text", kind=SpanKind.CLIENT, attributes=attributes) as span:
             try:
                 result = wrapped(*args, **kwargs)
                 if result and hasattr(result, "objects"):
                     span.set_attribute("db.vector.results.count", len(result.objects))
+                    summary = _weaviate_objects_summary(result.objects)
+                    if summary:
+                        span.set_attribute(_FI_OUTPUT_VALUE, summary)
+                        span.set_attribute(_FI_OUTPUT_MIME_TYPE, "application/json")
                 span.set_status(Status(StatusCode.OK))
                 return result
             except Exception as e:
@@ -102,11 +175,25 @@ class HybridWrapper(BaseWrapper):
         attributes["db.vector.query.top_k"] = limit
         attributes["db.vector.query.hybrid.alpha"] = alpha
 
+        # FI canonical retriever attributes.
+        attributes[_FI_SPAN_KIND] = _FI_RETRIEVER
+        if query:
+            attributes[_FI_INPUT_VALUE] = (
+                query if isinstance(query, str) else safe_json_dumps(query)
+            )
+            attributes[_FI_INPUT_MIME_TYPE] = (
+                "text/plain" if isinstance(query, str) else "application/json"
+            )
+
         with self._tracer.start_as_current_span("weaviate hybrid", kind=SpanKind.CLIENT, attributes=attributes) as span:
             try:
                 result = wrapped(*args, **kwargs)
                 if result and hasattr(result, "objects"):
                     span.set_attribute("db.vector.results.count", len(result.objects))
+                    summary = _weaviate_objects_summary(result.objects)
+                    if summary:
+                        span.set_attribute(_FI_OUTPUT_VALUE, summary)
+                        span.set_attribute(_FI_OUTPUT_MIME_TYPE, "application/json")
                 span.set_status(Status(StatusCode.OK))
                 return result
             except Exception as e:
@@ -124,11 +211,25 @@ class Bm25Wrapper(BaseWrapper):
         attributes = self._get_attributes("query", collection_name, "bm25")
         attributes["db.vector.query.top_k"] = limit
 
+        # FI canonical retriever attributes.
+        attributes[_FI_SPAN_KIND] = _FI_RETRIEVER
+        if query:
+            attributes[_FI_INPUT_VALUE] = (
+                query if isinstance(query, str) else safe_json_dumps(query)
+            )
+            attributes[_FI_INPUT_MIME_TYPE] = (
+                "text/plain" if isinstance(query, str) else "application/json"
+            )
+
         with self._tracer.start_as_current_span("weaviate bm25", kind=SpanKind.CLIENT, attributes=attributes) as span:
             try:
                 result = wrapped(*args, **kwargs)
                 if result and hasattr(result, "objects"):
                     span.set_attribute("db.vector.results.count", len(result.objects))
+                    summary = _weaviate_objects_summary(result.objects)
+                    if summary:
+                        span.set_attribute(_FI_OUTPUT_VALUE, summary)
+                        span.set_attribute(_FI_OUTPUT_MIME_TYPE, "application/json")
                 span.set_status(Status(StatusCode.OK))
                 return result
             except Exception as e:


### PR DESCRIPTION
## Summary

`WeaviateInstrumentor` emits spans for its four retrieval methods — `NearVector`, `NearText`, `Hybrid`, `Bm25` — but none of them set the FI canonical retriever keys. Future AGI dashboard renders all four as **Type: unknown** with empty Input/Output panels.

This PR adds three FI canonical attributes on all four retrieval wrappers. `FetchObjects`/`Insert`/`InsertMany`/`DeleteById`/`DeleteMany` are untouched — none are similarity retrievals.

## What changes

All in `traceai_weaviate/_wrappers.py`:

- Optional `fi_instrumentation.fi_types` import with raw-string fallback.
- New `_weaviate_objects_summary(objects)` helper — builds a JSON `[{uuid, properties, score?}, ...]` summary from the first 50 result objects.
- `NearVectorWrapper.__call__` — `kind=RETRIEVER`, `input.value` from `{limit, certainty, distance, vector_dim}` JSON, `output.value` from objects summary.
- `NearTextWrapper.__call__` — `kind=RETRIEVER`, `input.value` directly from the user's `query` string (`text/plain` mime — dashboard renders text inputs more cleanly than JSON), `output.value` from the same summary helper.
- `HybridWrapper.__call__` — same shape as NearText.
- `Bm25Wrapper.__call__` — same shape as NearText.

All pre-existing `db.vector.*` attrs preserved.

## Verified

- In-process attribute check via direct wrapper invocation with `SimpleNamespace(objects=[...])` results.
- Real end-to-end ingest to Future AGI → confirmed via Future AGI MCP that all four spans show:
  - `weaviate near_text` — Type=Retriever, Input=`\"where is the Eiffel Tower\"`, Output=`[{uuid, properties:{text:\"Eiffel Tower is in Paris.\"}, score:0.9}, ...]`
  - `weaviate near_vector` — Type=Retriever, Input=`{\"limit\": 2, \"vector_dim\": 3}`, Output=objects summary
  - `weaviate hybrid` — Type=Retriever, Input=`\"eiffel tower paris\"`, Output=objects summary
  - `weaviate bm25` — Type=Retriever, Input=`\"eiffel tower paris\"`, Output=objects summary

## Out of scope

Per-document `retrieval.documents.N.*` attrs (Tier 3). Other 6 vector DBs get their own PRs.