### PR TITLE
fix(pgvector): tag similarity-search SQL as RETRIEVER + populate input

### DIFF
--- a/python/frameworks/pgvector/traceai_pgvector/_wrappers.py
+++ b/python/frameworks/pgvector/traceai_pgvector/_wrappers.py
@@ -6,6 +6,20 @@ from typing import Any, Callable, Optional, Tuple
 
 from opentelemetry.trace import SpanKind, Status, StatusCode, Tracer
 
+# FI canonical span-kind / IO keys. Optional dependency.
+try:
+    from fi_instrumentation.fi_types import FiSpanKindValues, SpanAttributes
+
+    _FI_SPAN_KIND = SpanAttributes.FI_SPAN_KIND
+    _FI_INPUT_VALUE = SpanAttributes.INPUT_VALUE
+    _FI_INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
+    _FI_RETRIEVER = FiSpanKindValues.RETRIEVER.value
+except Exception:  # pragma: no cover
+    _FI_SPAN_KIND = "gen_ai.span.kind"
+    _FI_INPUT_VALUE = "input.value"
+    _FI_INPUT_MIME_TYPE = "input.mime_type"
+    _FI_RETRIEVER = "RETRIEVER"
+
 logger = logging.getLogger(__name__)
 
 # Vector operators in pgvector
@@ -95,6 +109,15 @@ class BaseWrapper:
         }
 
 
+def _is_pgvector_query_op(metadata: dict) -> bool:
+    """Return True iff this pgvector SQL is a similarity-search read."""
+    return metadata.get("db.operation.name") == "query"
+
+
+def _truncate_sql(sql: str, limit: int = 2000) -> str:
+    return sql if len(sql) <= limit else sql[:limit] + "...[truncated]"
+
+
 class ExecuteWrapper(BaseWrapper):
     def __call__(self, wrapped: Callable, instance: Any, args: tuple, kwargs: dict) -> Any:
         query = args[0] if args else ""
@@ -106,6 +129,21 @@ class ExecuteWrapper(BaseWrapper):
             distance_type, metadata = vector_info
             attributes = self._get_attributes()
             attributes.update(metadata)
+
+            # FI canonical retriever attributes — only on similarity-search
+            # reads (i.e. SELECT ... ORDER BY embedding <-> :query). Insert /
+            # update / delete vector ops aren't retrievals.
+            if _is_pgvector_query_op(metadata):
+                attributes[_FI_SPAN_KIND] = _FI_RETRIEVER
+                # Surface the SQL itself as input.value; the dashboard's
+                # Input panel renders this as the retrieval query.
+                sql_text = (
+                    query.as_string(None)
+                    if hasattr(query, "as_string")
+                    else str(query)
+                )
+                attributes[_FI_INPUT_VALUE] = _truncate_sql(sql_text)
+                attributes[_FI_INPUT_MIME_TYPE] = "text/plain"
 
             span_name = f"pgvector {metadata.get('db.operation.name', 'query')}"
 
@@ -136,6 +174,18 @@ class ExecuteManyWrapper(BaseWrapper):
             attributes = self._get_attributes()
             attributes.update(metadata)
             attributes["db.vector.batch.size"] = len(params_seq) if params_seq else 0
+
+            # FI canonical retriever attributes — only on similarity-search
+            # reads. Batched inserts/updates/deletes are not retrievals.
+            if _is_pgvector_query_op(metadata):
+                attributes[_FI_SPAN_KIND] = _FI_RETRIEVER
+                sql_text = (
+                    query.as_string(None)
+                    if hasattr(query, "as_string")
+                    else str(query)
+                )
+                attributes[_FI_INPUT_VALUE] = _truncate_sql(sql_text)
+                attributes[_FI_INPUT_MIME_TYPE] = "text/plain"
 
             span_name = f"pgvector {metadata.get('db.operation.name', 'batch')}"
 


### PR DESCRIPTION
## Summary

`PgvectorInstrumentor` wraps `psycopg.cursor.execute()` and `executemany()` and tags the span based on the SQL it sees: `query` for SELECT with a vector op, `insert`/`update`/`delete` otherwise. None of these currently set the FI canonical retriever keys, so a textbook RAG similarity-search query lands in Future AGI as **Type: unknown** with an empty Input panel.

This PR adds `gen_ai.span.kind = RETRIEVER` and `input.value` **only when the detected operation is a similarity-search read** (`db.operation.name == \"query\"`). INSERTs that happen to contain a vector operator (e.g. `INSERT ... RETURNING id <=> '[...]'`) are deliberately **not** tagged — they're writes, not retrievals.

## What changes

All in `traceai_pgvector/_wrappers.py`:

- Optional `fi_instrumentation.fi_types` import with raw-string fallback.
- New `_is_pgvector_query_op(metadata)` predicate — True iff the detected operation is `\"query\"`.
- New `_truncate_sql(sql, limit=2000)` helper.
- `ExecuteWrapper.__call__` and `ExecuteManyWrapper.__call__` — when `_is_pgvector_query_op(metadata)`:
  - `gen_ai.span.kind = \"RETRIEVER\"`
  - `input.value` = the SQL string (resolved via `as_string(None)` for psycopg `Composed` objects, else `str()`), truncated to 2000 chars
  - `input.mime_type = text/plain`

**Output is deliberately not set.** `psycopg.execute()` returns `None` (the rows live on the cursor, not the return value), so there's no clean way to capture results from this wrapping layer. The Output panel will remain empty for pgvector retriever spans — that's expected.

All pre-existing `db.vector.*` attrs preserved. INSERT/UPDATE/DELETE behavior is unchanged — they still get the existing pgvector technical attrs but without the RETRIEVER tag.

## Verified

- In-process attribute check on both positive and negative cases:
  - Similarity-search SQL → `gen_ai.span.kind = \"RETRIEVER\"`, `input.value` populated
  - INSERT containing a vector op → `gen_ai.span.kind` NOT set (correctly stays `None`/`unknown`)
- Real end-to-end ingest to Future AGI → confirmed via Future AGI MCP:
  - `pgvector query` (`SELECT ... embedding <=> '[...]' ORDER BY dist LIMIT 5`) → Type: Retriever, Input: full SQL string
  - `pgvector insert` (INSERT with a vector op) → Type: **unknown** ✅ (negative case correctly handled)

## Out of scope

- Output capture from psycopg results (would require wrapping `cursor.fetchall()` / iteration — separate concern).
- Per-document `retrieval.documents.N.*` attrs (Tier 3).
- Other 6 vector DBs get their own PRs.