### PR TITLE
test(crewai): assert gen_ai span attributes via SpanAttributes constants

### DIFF
--- a/python/tests/test_framework_crewai.py
+++ b/python/tests/test_framework_crewai.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from fi_instrumentation.fi_types import SpanAttributes
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.trace.status import Status, StatusCode
@@ -311,9 +312,15 @@ class TestKickoffWrapper:
         assert result == mock_output
         
         # Verify token metrics are set
-        self.mock_span.set_attribute.assert_any_call("llm.token_count.prompt", 200)
-        self.mock_span.set_attribute.assert_any_call("llm.token_count.completion", 100)
-        self.mock_span.set_attribute.assert_any_call("llm.token_count.total", 300)
+        self.mock_span.set_attribute.assert_any_call(
+            SpanAttributes.GEN_AI_USAGE_INPUT_TOKENS, 200
+        )
+        self.mock_span.set_attribute.assert_any_call(
+            SpanAttributes.GEN_AI_USAGE_OUTPUT_TOKENS, 100
+        )
+        self.mock_span.set_attribute.assert_any_call(
+            SpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS, 300
+        )
 
     def test_crew_kickoff_with_new_usage_metrics(self):
         """Test crew kickoff with new usage metrics format (v0.51+)."""
@@ -339,9 +346,15 @@ class TestKickoffWrapper:
         self.wrapper(wrapped_func, mock_crew, (), {})
         
         # Verify new format token metrics
-        self.mock_span.set_attribute.assert_any_call("llm.token_count.prompt", 150)
-        self.mock_span.set_attribute.assert_any_call("llm.token_count.completion", 75)
-        self.mock_span.set_attribute.assert_any_call("llm.token_count.total", 225)
+        self.mock_span.set_attribute.assert_any_call(
+            SpanAttributes.GEN_AI_USAGE_INPUT_TOKENS, 150
+        )
+        self.mock_span.set_attribute.assert_any_call(
+            SpanAttributes.GEN_AI_USAGE_OUTPUT_TOKENS, 75
+        )
+        self.mock_span.set_attribute.assert_any_call(
+            SpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS, 225
+        )
 
     def test_crew_kickoff_error_handling(self):
         """Test error handling in crew kickoff."""
@@ -426,7 +439,9 @@ class TestToolUseWrapper:
         
         # Verify tool attributes
         self.mock_span.set_attribute.assert_any_call("function_calling_llm", "gpt-4")
-        self.mock_span.set_attribute.assert_any_call("tool.name", "search_tool")
+        self.mock_span.set_attribute.assert_any_call(
+            SpanAttributes.GEN_AI_TOOL_NAME, "search_tool"
+        )
 
     def test_tool_use_without_tool(self):
         """Test tool usage without tool parameter."""
@@ -441,7 +456,7 @@ class TestToolUseWrapper:
         assert result == "no tool result"
         
         # Should set empty tool name
-        self.mock_span.set_attribute.assert_any_call("tool.name", "")
+        self.mock_span.set_attribute.assert_any_call(SpanAttributes.GEN_AI_TOOL_NAME, "")
 
     def test_tool_use_error_handling(self):
         """Test error handling in tool usage."""


### PR DESCRIPTION
Follow-up to #186. `python/tests/test_framework_crewai.py` has been **red on `dev`** — 4 failing tests — and nothing was gating on it. That is why the TH-6818 crash shipped.

## Root cause

The OTEL GenAI migration (`1dcebf8`) moved the crewai wrapper to the canonical `gen_ai.*` attributes:

- `llm.token_count.{prompt,completion,total}` → `SpanAttributes.GEN_AI_USAGE_{INPUT,OUTPUT,TOTAL}_TOKENS`
- `tool.name` → `SpanAttributes.GEN_AI_TOOL_NAME`

The suite was never updated. It still asserted the old **hardcoded string literals**, so the 4 assertions have been failing ever since.

**The code was correct; only the tests were stale.** No production behavior changes in this PR.

## The fix

Assert against the `SpanAttributes` constants the wrapper actually uses, instead of hardcoded literals. This matches the convention already followed by `test_framework_litellm.py` and `test_framework_llamaindex.py`, and it is what stops these assertions from silently rotting on the next rename.

`tests/test_framework_crewai.py`: **31 passed** (was 4 failed / 27 passed).

## Verification

These assertions genuinely bite — I mutation-tested them rather than trusting a green run:

- Reverting the wrapper to emit the old `tool.name` → 2 tests fail.
- Perturbing the emitted input-token value → 1 test fails.

So a regression back to the old attribute names, or a wrong token value, is caught.

## Known gap (deliberately not fixed here)

Asserting the constant pins *"the wrapper uses the right semantic attribute"*, not *"the attribute serializes to the right wire string"*. Nothing in `tests/` pins the literal value of `SpanAttributes.GEN_AI_*`, so renaming a constant's value would silently change the wire format for every downstream consumer while all tests stay green.

That belongs in a `fi_instrumentation` test, not a crewai framework suite — it is shared by 45+ frameworks. Happy to file it as its own ticket.