### PR TITLE
fix(config): honor full OTLP collector endpoint overrides

### DIFF
--- a/python/fi_instrumentation/otel.py
+++ b/python/fi_instrumentation/otel.py
@@ -629,6 +629,13 @@ def _printable_headers(
 
 
 def _construct_http_endpoint(parsed_endpoint: ParseResult) -> ParseResult:
+    # FI_COLLECTOR_ENDPOINT is documented as a full OTLP URL. Preserve an
+    # explicitly supplied path instead of appending the SDK default again.
+    if parsed_endpoint.path.rstrip("/") in {
+        "/v1/traces",
+        "/tracer/v1/traces",
+    }:
+        return parsed_endpoint
     return parsed_endpoint._replace(path="/tracer/v1/traces")
 
 

--- a/python/fi_instrumentation/settings.py
+++ b/python/fi_instrumentation/settings.py
@@ -12,11 +12,17 @@ logger = logging.getLogger(__name__)
 
 
 def get_env_collector_endpoint() -> Optional[str]:
-    return os.getenv("FI_BASE_URL", "https://api.futureagi.com")
+    return os.getenv(
+        "FI_COLLECTOR_ENDPOINT",
+        os.getenv("FI_BASE_URL", "https://api.futureagi.com"),
+    )
 
 
 def get_env_grpc_collector_endpoint() -> Optional[str]:
-    return os.getenv("FI_GRPC_URL", "https://grpc.futureagi.com")
+    return os.getenv(
+        "FI_GRPC_COLLECTOR_ENDPOINT",
+        os.getenv("FI_GRPC_URL", "https://grpc.futureagi.com"),
+    )
 
 
 def get_env_project_name() -> str:

--- a/python/tests/test_otel.py
+++ b/python/tests/test_otel.py
@@ -461,6 +461,13 @@ class TestUtilityFunctions:
         assert "api.example.com" in normalized_endpoint
         assert parsed.scheme in ["http", "https"]
 
+    def test_normalized_endpoint_preserves_full_otlp_path(self):
+        """Full collector overrides must not receive a duplicated OTLP path."""
+        _, normalized_endpoint = _normalized_endpoint(
+            "https://collector.example.com/v1/traces"
+        )
+        assert normalized_endpoint == "https://collector.example.com/v1/traces"
+
     def test_normalized_endpoint_grpc(self):
         """Test _normalized_endpoint with gRPC URL."""
         endpoint = "grpc://api.example.com:50051"
@@ -555,6 +562,5 @@ class TestIntegration:
         # Wait for all threads
         for thread in threads:
             thread.join()
-        
         # Just verify no major crashes occurred - threading behavior is unpredictable in tests
-        assert len(results) + len(errors) == 2  # Total should equal thread count 
+        assert len(results) + len(errors) == 2  # Total should equal thread count

--- a/python/tests/test_settings.py
+++ b/python/tests/test_settings.py
@@ -31,6 +31,12 @@ class TestEnvironmentVariableGetters:
         result = get_env_collector_endpoint()
         assert result == "https://custom.example.com"
 
+    def test_get_env_collector_endpoint_full_override(self, clean_env):
+        """A documented full collector URL takes precedence over FI_BASE_URL."""
+        os.environ["FI_BASE_URL"] = "https://base.example.com"
+        os.environ["FI_COLLECTOR_ENDPOINT"] = "https://collector.example.com/v1/traces"
+        assert get_env_collector_endpoint() == "https://collector.example.com/v1/traces"
+
     def test_get_env_grpc_collector_endpoint_default(self, clean_env):
         """Test default gRPC collector endpoint."""
         result = get_env_grpc_collector_endpoint()
@@ -41,6 +47,12 @@ class TestEnvironmentVariableGetters:
         os.environ["FI_GRPC_URL"] = "https://custom-grpc.example.com:50051"
         result = get_env_grpc_collector_endpoint()
         assert result == "https://custom-grpc.example.com:50051"
+
+    def test_get_env_grpc_collector_endpoint_full_override(self, clean_env):
+        """A documented full gRPC URL takes precedence over FI_GRPC_URL."""
+        os.environ["FI_GRPC_URL"] = "https://base-grpc.example.com:50051"
+        os.environ["FI_GRPC_COLLECTOR_ENDPOINT"] = "https://collector.example.com:50052"
+        assert get_env_grpc_collector_endpoint() == "https://collector.example.com:50052"
 
     def test_get_env_project_name_default(self, clean_env):
         """Test default project name."""
@@ -262,7 +274,6 @@ class TestCustomEvalTemplate:
     def test_get_custom_eval_template_request_failure(self, mock_requests):
         """Test custom eval template request failure."""
         mock_requests['post'].side_effect = Exception("Network error")
-        
         with pytest.raises(ValueError, match="Failed to check custom eval template"):
             get_custom_eval_template("test_eval")
 
@@ -271,4 +282,4 @@ class TestCustomEvalTemplate:
         mock_requests['response'].raise_for_status.side_effect = Exception("HTTP 404")
         
         with pytest.raises(ValueError, match="Failed to check custom eval template"):
-            get_custom_eval_template("test_eval") 
+            get_custom_eval_template("test_eval")

--- a/typescript/packages/fi-core/package.json
+++ b/typescript/packages/fi-core/package.json
@@ -56,6 +56,7 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@protobuf-ts/plugin": "^2.11.0",
     "@protobuf-ts/protoc": "^2.11.0",
     "@types/google-protobuf": "^3.15.12",

--- a/typescript/packages/fi-core/src/__tests__/otel.test.ts
+++ b/typescript/packages/fi-core/src/__tests__/otel.test.ts
@@ -90,6 +90,21 @@ describe('FI Core - OTEL Module', () => {
     });
   });
 
+  describe('collector endpoint configuration', () => {
+    it('prefers FI_COLLECTOR_ENDPOINT over FI_BASE_URL', () => {
+      process.env.FI_BASE_URL = 'https://base.example.com';
+      process.env.FI_COLLECTOR_ENDPOINT = 'https://collector.example.com/custom/v1/traces';
+
+      const provider = new FITracerProvider({ verbose: false });
+      expect((provider as any).endpoint).toBe(
+        'https://collector.example.com/custom/v1/traces',
+      );
+
+      delete process.env.FI_BASE_URL;
+      delete process.env.FI_COLLECTOR_ENDPOINT;
+    });
+  });
+
   describe('HTTPSpanExporter', () => {
     let exporter: HTTPSpanExporter;
     const mockEndpoint = 'https://test.example.com/api/spans';
@@ -463,4 +478,4 @@ describe('FI Core - OTEL Module', () => {
       expect(provider).toBeDefined();
     });
   });
-}); 
+});

--- a/typescript/packages/fi-core/src/otel.ts
+++ b/typescript/packages/fi-core/src/otel.ts
@@ -325,7 +325,23 @@ function constructFullEndpoint(customEndpoint?: string): string {
       baseUrlToUse = getEnv("FI_COLLECTOR_ENDPOINT") ?? getEnv("FI_BASE_URL") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
     }
   } else {
-    baseUrlToUse = getEnv("FI_COLLECTOR_ENDPOINT") ?? getEnv("FI_BASE_URL") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
+    const configuredEndpoint = getEnv("FI_COLLECTOR_ENDPOINT");
+    if (configuredEndpoint) {
+      try {
+        const parsedConfigured = new URL(configuredEndpoint);
+        if (
+          parsedConfigured.pathname !== "/" &&
+          parsedConfigured.pathname !== ""
+        ) {
+          return configuredEndpoint;
+        }
+      } catch (e) {
+        diag.warn(
+          `Configured FI_COLLECTOR_ENDPOINT '${configuredEndpoint}' is not a valid URL. Falling back to FI_BASE_URL.`,
+        );
+      }
+    }
+    baseUrlToUse = configuredEndpoint ?? getEnv("FI_BASE_URL") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
   }
   
   // Ensure no trailing slash from baseUrl before appending path

--- a/typescript/packages/fi-core/src/otel.ts
+++ b/typescript/packages/fi-core/src/otel.ts
@@ -313,7 +313,7 @@ function constructFullEndpoint(customEndpoint?: string): string {
       const parsedCustom = new URL(customEndpoint);
       if (!parsedCustom.protocol || !parsedCustom.host) {
         diag.warn(`Custom endpoint '${customEndpoint}' is missing protocol or host. Falling back to environment or default.`);
-        baseUrlToUse = getEnv("FI_BASE_URL") ?? getEnv("FI_COLLECTOR_ENDPOINT") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
+        baseUrlToUse = getEnv("FI_COLLECTOR_ENDPOINT") ?? getEnv("FI_BASE_URL") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
       } else if (parsedCustom.pathname !== "/" && parsedCustom.pathname !== FI_COLLECTOR_PATH) {
         diag.warn(`Using custom endpoint as full URL: ${customEndpoint}`);
         return customEndpoint;
@@ -322,10 +322,10 @@ function constructFullEndpoint(customEndpoint?: string): string {
       }
     } catch (e) {
       diag.warn(`Custom endpoint '${customEndpoint}' is not a valid URL. Falling back to environment or default.`);
-      baseUrlToUse = getEnv("FI_BASE_URL") ?? getEnv("FI_COLLECTOR_ENDPOINT") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
+      baseUrlToUse = getEnv("FI_COLLECTOR_ENDPOINT") ?? getEnv("FI_BASE_URL") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
     }
   } else {
-    baseUrlToUse = getEnv("FI_BASE_URL") ?? getEnv("FI_COLLECTOR_ENDPOINT") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
+    baseUrlToUse = getEnv("FI_COLLECTOR_ENDPOINT") ?? getEnv("FI_BASE_URL") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
   }
   
   // Ensure no trailing slash from baseUrl before appending path
@@ -655,10 +655,10 @@ async function checkCustomEvalConfigExists(
       }
     } catch (e) {
       if (verbose) diag.warn(`checkCustomEvalConfigExists: Custom endpoint '${customEndpoint}' is not a valid URL. Falling back to environment or default.`);
-      apiBaseUrl = getEnv("FI_BASE_URL") ?? getEnv("FI_COLLECTOR_ENDPOINT") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
+      apiBaseUrl = getEnv("FI_COLLECTOR_ENDPOINT") ?? getEnv("FI_BASE_URL") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
     }
   } else {
-    apiBaseUrl = getEnv("FI_BASE_URL") ?? getEnv("FI_COLLECTOR_ENDPOINT") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
+    apiBaseUrl = getEnv("FI_COLLECTOR_ENDPOINT") ?? getEnv("FI_BASE_URL") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
   }
 
   if (apiBaseUrl.endsWith('/')) {
@@ -735,10 +735,10 @@ export async function checkCustomEvalTemplateExists(
       }
     } catch (e) {
       if (verbose) diag.warn(`checkCustomEvalTemplateExists: Custom endpoint '${customEndpoint}' is not a valid URL. Falling back to environment or default.`);
-      apiBaseUrl = getEnv("FI_BASE_URL") ?? getEnv("FI_COLLECTOR_ENDPOINT") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
+      apiBaseUrl = getEnv("FI_COLLECTOR_ENDPOINT") ?? getEnv("FI_BASE_URL") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
     }
   } else {
-    apiBaseUrl = getEnv("FI_BASE_URL") ?? getEnv("FI_COLLECTOR_ENDPOINT") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
+    apiBaseUrl = getEnv("FI_COLLECTOR_ENDPOINT") ?? getEnv("FI_BASE_URL") ?? DEFAULT_FI_COLLECTOR_BASE_URL;
   }
 
   if (apiBaseUrl.endsWith('/')) {
@@ -811,4 +811,4 @@ export {
 // - Implement prepareEvalTags (similar to Python)
 // - Implement checkCustomEvalConfigExists
 // - Refine error handling and logging
-// - Add tests 
+// - Add tests

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
     devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
       '@protobuf-ts/plugin':
         specifier: ^2.11.0
         version: 2.11.1


### PR DESCRIPTION
## Summary

- honor the documented FI_COLLECTOR_ENDPOINT and FI_GRPC_COLLECTOR_ENDPOINT overrides before the base URL fallbacks
- preserve an explicitly supplied /v1/traces or /tracer/v1/traces path instead of appending a duplicate path
- add regression tests for HTTP/gRPC override precedence and full HTTP endpoint normalization

This makes the SDK's documented endpoint configuration reliable for self-hosted collectors and prevents credentials from being sent to an unintended URL. It is relevant to the authentication/export failure reported in #155.

## Verification

- Python compilation passed for changed modules and tests
- git diff --check passed
- focused pytest is blocked locally because opentelemetry is not installed in the workspace