### PR TITLE
docs: fix typos in Python examples

### DIFF
--- a/python/frameworks/haystack/examples/building_fallbacks_with_conditional_routing.py
+++ b/python/frameworks/haystack/examples/building_fallbacks_with_conditional_routing.py
@@ -87,7 +87,7 @@ llm = OpenAIGenerator(model="gpt-3.5-turbo")
 
 prompt_for_websearch = """
 Answer the following query given the documents retrieved from the web.
-Your answer shoud indicate that your answer was generated from websearch.
+Your answer should indicate that your answer was generated from websearch.
 
 Query: {{query}}
 Documents:

--- a/python/frameworks/llama_index/examples/ingestion_pipeline.py
+++ b/python/frameworks/llama_index/examples/ingestion_pipeline.py
@@ -56,7 +56,7 @@ with tempfile.NamedTemporaryFile() as tf:
     documents = SimpleDirectoryReader(input_files=[tf.name]).load_data()
 
 llm = OpenAI(model="gpt-3.5-turbo", temperature=0.1)
-pipline = IngestionPipeline(
+pipeline = IngestionPipeline(
     transformations=[
         SentenceSplitter(chunk_size=1024, chunk_overlap=20),
         TitleExtractor(llm=llm, metadata_mode=MetadataMode.EMBED, num_workers=8),
@@ -66,4 +66,4 @@ pipline = IngestionPipeline(
 )
 
 if __name__ == "__main__":
-    nodes = pipline.run(documents=documents)
+    nodes = pipeline.run(documents=documents)

--- a/python/frameworks/vertexai/examples/vertexai.model.count_tokens.py
+++ b/python/frameworks/vertexai/examples/vertexai.model.count_tokens.py
@@ -38,5 +38,5 @@ model = GenerativeModel("gemini-1.5-flash")
 
 
 if __name__ == "__main__":
-    response = model.count_tokens("Write an artice on AGI.")
+    response = model.count_tokens("Write an article on AGI.")
     print(response)


### PR DESCRIPTION
## What does this PR do?

Corrects three typos in Python examples: a Haystack prompt, a LlamaIndex pipeline variable, and a Vertex AI sample prompt.

## Why?

These examples are copied by users, so the prompt text and identifiers should be clear and correctly spelled.

## How was it tested?

- [x] Unit tests added / updated (N/A - example text and identifier corrections only)
- [x] Integration tests pass (N/A - no gateway behavior changed)
- [x] `ruff check` passes for all three changed files
- [x] All three changed files compile with `python -m py_compile`
- [x] `codespell` passes for all three changed files
- [x] Public types, env vars, or SDK behavior changes are documented (N/A - none changed)

## Checklist

- [x] Branch is off `main`
- [x] Commit messages follow Conventional Commits
- [x] No TODOs or commented-out code left in
- [x] No real API keys or secrets in the diff
- [x] Prose changes do not introduce new project terminology

## Notes for reviewers

No runtime behavior or public API changes.